### PR TITLE
feat: add callback when navigation is finished

### DIFF
--- a/lib/src/lib/nav-list/components/nav-item/nav-item.component.ts
+++ b/lib/src/lib/nav-list/components/nav-item/nav-item.component.ts
@@ -64,7 +64,11 @@ export class NavItemComponent extends SubscriptionBasedDirective implements OnIn
     if (this.item?.children?.length) {
       this.expanded = !this.expanded;
     } else if (this.item?.route) {
-      this.router.navigate([this.item.route], { queryParams: this.item?.routeQueryParams });
+      this.router.navigate([this.item.route], { queryParams: this.item?.routeQueryParams }).then((navigationResult: boolean) => {
+        if (this.item?.navigationFinished) {
+          this.item.navigationFinished(navigationResult);
+        }
+      });
     } else if (this.item?.href?.url) {
       window.open(this.item.href.url, this.item.href?.target ?? '_blank');
     }

--- a/lib/src/lib/nav-list/models/nav-item.model.ts
+++ b/lib/src/lib/nav-list/models/nav-item.model.ts
@@ -9,6 +9,7 @@ export interface NavItem {
   children?: NavItem[];
   childrenInOverlay?: boolean;
   hide?: (() => boolean) | boolean;
+  navigationFinished?: (navigationResult: boolean | null) => void;
 }
 
 export interface NavItemGroup {


### PR DESCRIPTION
## Purpose

To add the possibility to pass a callback when the navigation is finished

## Approach

- after the promise of navigate is finished and if the calback exists we call the callback with the result of the navigation.
