### PR TITLE
added support for left-aligning action buttons on page header

### DIFF
--- a/lib/src/lib/button/models/action-button.model.ts
+++ b/lib/src/lib/button/models/action-button.model.ts
@@ -17,6 +17,7 @@ export interface ActionButton<T = any> {
   prefixIcon?: propValue<T>;
   svgIcon?: boolean;
   containerClass?: string;
+  align?: 'left' | 'right';
 }
 
 export interface ToggleActionButton<T = any> extends ActionButton<T> {

--- a/lib/src/lib/page-header/components/page-header/page-header.component.html
+++ b/lib/src/lib/page-header/components/page-header/page-header.component.html
@@ -6,12 +6,32 @@
     fxLayoutGap="16px"
     fxLayoutAlign.gt-sm="space-between center"
   >
-    <div>
+    <div class="lab900-page-header__title">
       <h1 *ngIf="pageTitle">{{ pageTitle | translate: pageTitleArgs }}</h1>
       <lab900-bread-crumbs *ngIf="breadCrumbs?.length" [breadCrumbs]="breadCrumbs" [data]="data"></lab900-bread-crumbs>
     </div>
-    <div class="lab900-page-header__actions" *ngIf="actions?.length" fxLayout="row" fxLayoutGap="16px" fxLayoutAlign.lt-md="center">
-      <lab900-action-button *ngFor="let action of actions" [action]="action" [data]="data"></lab900-action-button>
+
+    <div
+      class="lab900-page-header__actions"
+      *ngIf="leftActions?.length"
+      fxLayout="row"
+      fxLayoutGap="16px"
+      fxLayoutAlign.lt-md="center"
+      fxFill
+    >
+      <mat-divider vertical="true"></mat-divider>
+      <lab900-action-button *ngFor="let action of leftActions" [action]="action" [data]="data"></lab900-action-button>
+    </div>
+    <div
+      class="lab900-page-header__actions"
+      *ngIf="rightActions?.length"
+      fxLayout="row"
+      fxLayoutGap="16px"
+      fxLayoutAlign="end"
+      fxLayoutAlign.lt-md="center"
+      fxFill
+    >
+      <lab900-action-button *ngFor="let action of rightActions" [action]="action" [data]="data"></lab900-action-button>
     </div>
   </div>
   <nav *ngIf="navItems?.length" class="lab900-page-header__nav" mat-tab-nav-bar>

--- a/lib/src/lib/page-header/components/page-header/page-header.component.scss
+++ b/lib/src/lib/page-header/components/page-header/page-header.component.scss
@@ -5,6 +5,13 @@
     }
   }
 
+  &__title {
+    min-width: fit-content;
+  }
+  &__actions {
+    min-width: unset !important;
+  }
+
   @media screen and (min-width: 960px) {
     &__nav {
       padding: 0 50px;

--- a/lib/src/lib/page-header/components/page-header/page-header.component.ts
+++ b/lib/src/lib/page-header/components/page-header/page-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { PageHeaderNavItem } from '../../models/page-header-nav.model';
 import { ActionButton } from '../../../button/models/action-button.model';
 import { BreadCrumb } from '../../../bread-crumbs/models/bread-crumb.model';
@@ -9,7 +9,7 @@ import { readPropValue } from '../../../utils/utils';
   templateUrl: './page-header.component.html',
   styleUrls: ['./page-header.component.scss'],
 })
-export class Lab900PageHeaderComponent implements OnInit {
+export class Lab900PageHeaderComponent implements OnChanges {
   @Input()
   public pageTitle: string;
 
@@ -30,9 +30,9 @@ export class Lab900PageHeaderComponent implements OnInit {
   @Input()
   public breadCrumbs: BreadCrumb[];
 
-  public ngOnInit(): void {
-    this.leftActions = this.actions.filter((action) => action.align === 'left');
-    this.rightActions = this.actions.filter((action) => action.align === 'right' || action.align == null);
+  public ngOnChanges(): void {
+    this.leftActions = this.actions?.filter((action) => action.align === 'left');
+    this.rightActions = this.actions?.filter((action) => action.align === 'right' || action.align == null);
   }
 
   public getLabel(item: PageHeaderNavItem): string {

--- a/lib/src/lib/page-header/components/page-header/page-header.component.ts
+++ b/lib/src/lib/page-header/components/page-header/page-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { PageHeaderNavItem } from '../../models/page-header-nav.model';
 import { ActionButton } from '../../../button/models/action-button.model';
 import { BreadCrumb } from '../../../bread-crumbs/models/bread-crumb.model';
@@ -9,7 +9,7 @@ import { readPropValue } from '../../../utils/utils';
   templateUrl: './page-header.component.html',
   styleUrls: ['./page-header.component.scss'],
 })
-export class Lab900PageHeaderComponent {
+export class Lab900PageHeaderComponent implements OnInit {
   @Input()
   public pageTitle: string;
 
@@ -21,12 +21,19 @@ export class Lab900PageHeaderComponent {
 
   @Input()
   public actions: ActionButton[];
+  public leftActions: ActionButton[];
+  public rightActions: ActionButton[];
 
   @Input()
   public data?: any;
 
   @Input()
   public breadCrumbs: BreadCrumb[];
+
+  public ngOnInit(): void {
+    this.leftActions = this.actions.filter((action) => action.align === 'left');
+    this.rightActions = this.actions.filter((action) => action.align === 'right' || action.align == null);
+  }
 
   public getLabel(item: PageHeaderNavItem): string {
     if (typeof item.label === 'function') {

--- a/lib/src/lib/page-header/components/page-header/page-header.component.ts
+++ b/lib/src/lib/page-header/components/page-header/page-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { PageHeaderNavItem } from '../../models/page-header-nav.model';
 import { ActionButton } from '../../../button/models/action-button.model';
 import { BreadCrumb } from '../../../bread-crumbs/models/bread-crumb.model';
@@ -30,9 +30,11 @@ export class Lab900PageHeaderComponent implements OnChanges {
   @Input()
   public breadCrumbs: BreadCrumb[];
 
-  public ngOnChanges(): void {
-    this.leftActions = this.actions?.filter((action) => action.align === 'left');
-    this.rightActions = this.actions?.filter((action) => action.align === 'right' || action.align == null);
+  public ngOnChanges(changes: SimpleChanges): void {
+    if (changes.actions) {
+      this.leftActions = this.actions?.filter((action) => action.align === 'left');
+      this.rightActions = this.actions?.filter((action) => action.align === 'right' || action.align == null);
+    }
   }
 
   public getLabel(item: PageHeaderNavItem): string {

--- a/lib/src/lib/page-header/page-header.module.ts
+++ b/lib/src/lib/page-header/page-header.module.ts
@@ -8,6 +8,7 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 import { MatMenuModule } from '@angular/material/menu';
 import { Lab900ButtonModule } from '../button/button.module';
 import { BreadCrumbsModule } from '../bread-crumbs/bread-crumbs.module';
+import { MatDividerModule } from '@angular/material/divider';
 
 @NgModule({
   declarations: [Lab900PageHeaderComponent],
@@ -21,6 +22,7 @@ import { BreadCrumbsModule } from '../bread-crumbs/bread-crumbs.module';
     MatMenuModule,
     Lab900ButtonModule,
     BreadCrumbsModule,
+    MatDividerModule,
   ],
 })
 export class Lab900PageHeaderModule {}

--- a/src/app/modules/showcase-ui/examples/page-header-params-example/page-header-params-example.component.ts
+++ b/src/app/modules/showcase-ui/examples/page-header-params-example/page-header-params-example.component.ts
@@ -30,6 +30,12 @@ export class PageHeaderParamsExampleComponent {
       type: 'flat',
     },
     {
+      label: 'Left btn',
+      action: () => console.log('Left btn'),
+      type: 'flat',
+      align: 'left',
+    },
+    {
       label: 'Save',
       action: () => console.log('save'),
       type: 'flat',


### PR DESCRIPTION
added variable to align a button to the left (default will still be on the right)
```typescript 
public actions: ActionButton[] = [
    {
      label: 'Left btn',
      align: 'left',
    },
]

```
## screenshot
![image](https://user-images.githubusercontent.com/84316505/127021705-1f8950c4-70bb-40d6-83aa-212d94af2eff.png)