### PR TITLE
Added the option to have table footer actions

### DIFF
--- a/lib/src/lib/table/components/table/table.component.html
+++ b/lib/src/lib/table/components/table/table.component.html
@@ -78,15 +78,22 @@
     </table>
   </div>
 
-  <mat-paginator
-    *ngIf="data?.length && paging"
-    [hidePageSize]="pageSizeConfig.hidePageSize"
-    [pageSizeOptions]="pageSizeConfig.pageSizeOptions"
-    [length]="paging.totalItems"
-    [pageSize]="paging.pageSize"
-    [pageIndex]="paging.pageIndex"
-    (page)="pageChange.emit($event)"
-  ></mat-paginator>
+  <div class="lab900-table__footer" *ngIf="tableFooterActions?.length || (data?.length && paging)">
+    <div>
+      <div class="lab900-table__footer__actions" *ngIf="tableFooterActions?.length">
+        <lab900-action-button *ngFor="let action of tableFooterActions" [action]="action"></lab900-action-button>
+      </div>
+    </div>
+    <mat-paginator
+      *ngIf="data?.length && paging"
+      [hidePageSize]="pageSizeConfig.hidePageSize"
+      [pageSizeOptions]="pageSizeConfig.pageSizeOptions"
+      [length]="paging.totalItems"
+      [pageSize]="paging.pageSize"
+      [pageIndex]="paging.pageIndex"
+      (page)="pageChange.emit($event)"
+    ></mat-paginator>
+  </div>
 
   <div class="lab900-table__empty" *ngIf="data && !data.length && !disabled">
     <ng-container *ngIf="emptyTableTemplate">

--- a/lib/src/lib/table/components/table/table.component.scss
+++ b/lib/src/lib/table/components/table/table.component.scss
@@ -63,4 +63,30 @@
   &__mat-tooltip {
     min-width: fit-content;
   }
+
+  &__footer {
+    @media screen and (min-width: 600px) {
+      display: flex;
+      align-items: center;
+    }
+
+    > div {
+      flex: 1;
+    }
+
+    &__actions {
+      display: flex;
+      flex-flow: row wrap;
+      align-items: center;
+      margin: 0 -4px;
+
+      @media screen and (max-width: 600px) {
+        margin: 10px -4px 0;
+      }
+
+      lab900-action-button {
+        padding: 0 4px;
+      }
+    }
+  }
 }

--- a/lib/src/lib/table/components/table/table.component.ts
+++ b/lib/src/lib/table/components/table/table.component.ts
@@ -96,6 +96,12 @@ export class Lab900TableComponent implements OnChanges {
   public tableHeaderActions: ActionButton[];
 
   /**
+   * Show a set of action at the bottom of the table
+   */
+  @Input()
+  public tableFooterActions: ActionButton[];
+
+  /**
    * Show a set of action at the start of each row
    */
   @Input()

--- a/src/app/modules/showcase-ui/examples/table-example/table-example.component.ts
+++ b/src/app/modules/showcase-ui/examples/table-example/table-example.component.ts
@@ -22,6 +22,7 @@ import { ActionButton, Lab900Sort, Paging, TableCell } from '@lab900/ui';
     [rowClass]="getRowClass"
     (tableCellsFiltered)="filtered($event)"
     [maxColumnWidth]="'200px'"
+    [tableFooterActions]="tableFooterActions"
   >
     <div *lab900TableTopContent>Custom top content</div>
     <div *lab900TableHeaderContent>Custom header</div>
@@ -39,6 +40,19 @@ import { ActionButton, Lab900Sort, Paging, TableCell } from '@lab900/ui';
 })
 export class TableExampleComponent {
   public sort: Lab900Sort[] = [{ id: 'id', direction: 'asc' }];
+
+  public tableFooterActions: ActionButton[] = [
+    {
+      label: 'Kies een locatie',
+      type: 'flat',
+      align: 'left',
+    },
+    {
+      label: 'Button',
+      type: 'stroked',
+      align: 'right',
+    },
+  ];
 
   public tableHeaderActions: ActionButton[] = [
     {

--- a/src/app/modules/showcase-ui/examples/table-example/table-example.component.ts
+++ b/src/app/modules/showcase-ui/examples/table-example/table-example.component.ts
@@ -45,12 +45,10 @@ export class TableExampleComponent {
     {
       label: 'Kies een locatie',
       type: 'flat',
-      align: 'left',
     },
     {
       label: 'Button',
       type: 'stroked',
-      align: 'right',
     },
   ];
 


### PR DESCRIPTION
## Purpose

An option for table footer actions next to the pagination

## Approach

Added a new input `tableFooterActions` which works like the header actions.

![Schermafbeelding 2021-08-06 om 14 38 09](https://user-images.githubusercontent.com/13655941/128511916-aace2498-2c5e-4efc-91b7-376f4c6d59bc.png)
