### PR TITLE
Bugfix/page header responsive

### DIFF
--- a/lib/src/lib/page-header/components/page-header/page-header.component.html
+++ b/lib/src/lib/page-header/components/page-header/page-header.component.html
@@ -4,34 +4,21 @@
     class="lab900-page-header__main"
     fxLayout.gt-sm="row"
     fxLayoutGap="16px"
-    fxLayoutAlign.gt-sm="space-between center"
+    fxLayoutAlign.gt-sm="start center"
   >
     <div class="lab900-page-header__title">
       <h1 *ngIf="pageTitle">{{ pageTitle | translate: pageTitleArgs }}</h1>
       <lab900-bread-crumbs *ngIf="breadCrumbs?.length" [breadCrumbs]="breadCrumbs" [data]="data"></lab900-bread-crumbs>
     </div>
 
-    <div
-      class="lab900-page-header__actions"
-      *ngIf="leftActions?.length"
-      fxLayout="row"
-      fxLayoutGap="16px"
-      fxLayoutAlign.lt-md="center"
-      fxFill
-    >
-      <mat-divider vertical="true"></mat-divider>
-      <lab900-action-button *ngFor="let action of leftActions" [action]="action" [data]="data"></lab900-action-button>
-    </div>
-    <div
-      class="lab900-page-header__actions"
-      *ngIf="rightActions?.length"
-      fxLayout="row"
-      fxLayoutGap="16px"
-      fxLayoutAlign="end"
-      fxLayoutAlign.lt-md="center"
-      fxFill
-    >
-      <lab900-action-button *ngFor="let action of rightActions" [action]="action" [data]="data"></lab900-action-button>
+    <div class="lab900-page-header__actions" *ngIf="actions?.length">
+      <div class="lab900-page-header__actions--left" fxLayoutGap="16px">
+        <mat-divider vertical="true" class="lab900-page-header__divider" *ngIf="leftActions?.length > 0"></mat-divider>
+        <lab900-action-button *ngFor="let action of leftActions" [action]="action" [data]="data"></lab900-action-button>
+      </div>
+      <div class="lab900-page-header__actions--right" fxLayoutGap="16px">
+        <lab900-action-button *ngFor="let action of rightActions" [action]="action" [data]="data"></lab900-action-button>
+      </div>
     </div>
   </div>
   <nav *ngIf="navItems?.length" class="lab900-page-header__nav" mat-tab-nav-bar>

--- a/lib/src/lib/page-header/components/page-header/page-header.component.scss
+++ b/lib/src/lib/page-header/components/page-header/page-header.component.scss
@@ -10,6 +10,20 @@
   }
   &__actions {
     min-width: unset !important;
+    flex: 1;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    &--left {
+      display: flex;
+      justify-content: flex-start;
+      margin-right: 16px;
+    }
+    &--right {
+      display: flex;
+      justify-content: flex-end;
+      flex-wrap: wrap;
+    }
   }
 
   @media screen and (min-width: 960px) {
@@ -36,6 +50,12 @@
       bottom: 0;
       left: 0;
       right: 0;
+      align-items: center;
+      justify-content: center;
+    }
+
+    &__divider {
+      display: none;
     }
   }
 


### PR DESCRIPTION
Page headers are now responsive, instead of giving a blank page. 
For left buttons, right buttons, or both

## screenshots
![image](https://user-images.githubusercontent.com/84316505/128687351-bef41241-3289-4ac3-8f4c-073159f90182.png)
![image](https://user-images.githubusercontent.com/84316505/128687403-510222a1-9971-40b4-b73d-04ecbd4a1cc4.png)
![image](https://user-images.githubusercontent.com/84316505/128687520-6e1911e0-908a-4de2-b774-b7eeeb1df011.png)

