### PR TITLE
feat: inject data to action button disable option

### DIFF
--- a/lib/src/lib/button/components/action-button-menu/lab900-action-button-menu.component.ts
+++ b/lib/src/lib/button/components/action-button-menu/lab900-action-button-menu.component.ts
@@ -22,7 +22,7 @@ export class Lab900ActionButtonMenuComponent {
   }
 
   public getDisabled(action: ActionButton): boolean {
-    return readPropValue(action.disabled, this.data);
+    return readPropValue(typeof action.disabled === 'function' ? action.disabled(this.data) : action.disabled, this.data);
   }
 
   public doAction(e: Event, action: ActionButton): void {

--- a/lib/src/lib/button/components/action-button-toggle/lab900-action-button-toggle.component.ts
+++ b/lib/src/lib/button/components/action-button-toggle/lab900-action-button-toggle.component.ts
@@ -36,11 +36,11 @@ export class Lab900ActionButtonToggleComponent {
   }
 
   public getDisabled(): boolean {
-    return readPropValue(this.action.disabled, this.data);
+    return readPropValue(typeof this.action.disabled === 'function' ? this.action.disabled(this.data) : this.action.disabled, this.data);
   }
 
   public getSubActionDisabled(action: ActionButton): boolean {
-    return readPropValue(action.disabled, this.data);
+    return readPropValue(typeof action.disabled === 'function' ? action.disabled(this.data) : action.disabled, this.data);
   }
 
   public doAction(e: Event): void {

--- a/lib/src/lib/button/components/action-button/lab900-action-button.component.ts
+++ b/lib/src/lib/button/components/action-button/lab900-action-button.component.ts
@@ -48,7 +48,7 @@ export class Lab900ActionButtonComponent {
   }
 
   public getDisabled(): boolean {
-    return readPropValue(this.action.disabled, this.data);
+    return readPropValue(typeof this.action.disabled === 'function' ? this.action.disabled(this.data) : this.action.disabled, this.data);
   }
 
   public doAction(e: Event): void {

--- a/lib/src/lib/button/models/action-button.model.ts
+++ b/lib/src/lib/button/models/action-button.model.ts
@@ -8,7 +8,7 @@ export interface ActionButton<T = any> {
   action?: (data?: T, e?: Event) => any;
   type?: propValue<T, 'toggle' | Lab900ButtonType>;
   color?: propValue<T, ThemePalette>;
-  disabled?: propValue<T, boolean>;
+  disabled?: propValue<T, boolean> | ((data?: T) => propValue<T, boolean>);
   selected?: propValue<T, boolean>;
   hide?: propValue<T, boolean>;
   subActions?: ActionButton<T>[];


### PR DESCRIPTION
To add the possibility to receive the data passed when defining the `disabled` option for a action button