### PR TITLE
:sparkles: feat(table): support custom column header component

### DIFF
--- a/lib/src/lib/table/components/table-cell/table-cell.component.html
+++ b/lib/src/lib/table/components/table-cell/table-cell.component.html
@@ -1,13 +1,20 @@
 <ng-container matColumnDef [sticky]="cell.sticky">
   <th mat-header-cell *matHeaderCellDef (click)="headerClick.emit(cell)" [class.sortable]="cell.sortable" [ngClass]="cellHeaderClass">
-    <div>
-      <mat-icon *ngIf="cellHeaderIcon as icon">{{ icon }}</mat-icon>
-      <mat-icon *ngIf="cellHeaderSvgIcon as icon" [svgIcon]="icon"></mat-icon>
-      {{ cellLabel | translate }}
-      <span class="material-icons lab900-sort-arrow" *ngIf="cell.sortable && sortDirection">
-        {{ sortIcon }}
-      </span>
-    </div>
+    <ng-container *ngIf="cell?.customHeaderCell && customHeaderCell; else defaultHeader">
+      <ng-container
+        *ngTemplateOutlet="customHeaderCell; context: { $implicit: { cell: cell, sortDirection: sortDirection } }"
+      ></ng-container>
+    </ng-container>
+    <ng-template #defaultHeader>
+      <div>
+        <mat-icon *ngIf="cellHeaderIcon as icon">{{ icon }}</mat-icon>
+        <mat-icon *ngIf="cellHeaderSvgIcon as icon" [svgIcon]="icon"></mat-icon>
+        {{ cellLabel | translate }}
+        <span class="material-icons lab900-sort-arrow" *ngIf="cell.sortable && sortDirection">
+          {{ sortIcon }}
+        </span>
+      </div>
+    </ng-template>
   </th>
   <td mat-cell *matCellDef="let element" [style.width]="cell?.width === '*' ? '100%' : cell?.width" [ngClass]="getCellClass(element)">
     <ng-container *ngIf="cell?.customCellContent && customCellContent">

--- a/lib/src/lib/table/components/table-cell/table-cell.component.ts
+++ b/lib/src/lib/table/components/table-cell/table-cell.component.ts
@@ -5,6 +5,7 @@ import { SortDirection } from '@angular/material/sort';
 import { MatColumnDef } from '@angular/material/table';
 import { readPropValue } from '../../../utils/utils';
 import { Lab900Sort } from '../../models/table-sort.model';
+import { Lab900TableCustomHeaderCellDirective } from '../../directives/table-custom-header-cell.directive';
 
 @Component({
   selector: 'lab900-table-cell',
@@ -42,6 +43,9 @@ export class Lab900TableCellComponent<T = any> {
 
   @Input()
   public customCellContent?: Lab900TableCustomCellDirective;
+
+  @Input()
+  public customHeaderCell?: Lab900TableCustomHeaderCellDirective;
 
   @Input()
   public data: T[];

--- a/lib/src/lib/table/components/table/table.component.html
+++ b/lib/src/lib/table/components/table/table.component.html
@@ -66,6 +66,7 @@
         [sort]="sort"
         [maxColumnWidthFromTable]="maxColumnWidth"
         [customCellContent]="customCellContent"
+        [customHeaderCell]="customHeaderCell"
         (headerClick)="handleHeaderClick($event)"
         [data]="data"
       ></lab900-table-cell>

--- a/lib/src/lib/table/components/table/table.component.ts
+++ b/lib/src/lib/table/components/table/table.component.ts
@@ -29,6 +29,7 @@ import { CdkDragDrop } from '@angular/cdk/drag-drop';
 import { ThemePalette } from '@angular/material/core';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { Lab900Sort } from '../../models/table-sort.model';
+import { Lab900TableCustomHeaderCellDirective } from '../../directives/table-custom-header-cell.directive';
 
 type propFunction<T, R = string> = (data: T) => R;
 
@@ -231,6 +232,9 @@ export class Lab900TableComponent<T extends object = object> implements OnChange
 
   @ContentChild(Lab900TableCustomCellDirective, { read: TemplateRef })
   public customCellContent?: Lab900TableCustomCellDirective;
+
+  @ContentChild(Lab900TableCustomHeaderCellDirective, { read: TemplateRef })
+  public customHeaderCell?: Lab900TableCustomHeaderCellDirective;
 
   public displayedColumns: string[] = [];
 

--- a/lib/src/lib/table/directives/table-custom-header-cell.directive.ts
+++ b/lib/src/lib/table/directives/table-custom-header-cell.directive.ts
@@ -1,0 +1,7 @@
+import { Directive } from '@angular/core';
+
+@Directive({
+  // tslint:disable-next-line:directive-selector
+  selector: '[lab900TableCustomHeaderCell]',
+})
+export class Lab900TableCustomHeaderCellDirective {}

--- a/lib/src/lib/table/models/table-cell.model.ts
+++ b/lib/src/lib/table/models/table-cell.model.ts
@@ -64,6 +64,10 @@ export interface TableCell<T = any> {
    */
   customCellContent?: boolean;
   /**
+   * render a different column header template
+   */
+  customHeaderCell?: boolean;
+  /**
    * Enable a tooltip, displays the cell content in a tooltip
    */
   cellTooltip?: TableCellTooltip<T>;

--- a/lib/src/lib/table/table.module.ts
+++ b/lib/src/lib/table/table.module.ts
@@ -23,6 +23,7 @@ import { Lab900TableHeaderContentDirective } from './directives/table-header-con
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { Lab900ButtonModule } from '../button/button.module';
 import { Lab900TableCustomCellDirective } from './directives/table-custom-cell.directive';
+import { Lab900TableCustomHeaderCellDirective } from './directives/table-custom-header-cell.directive';
 import { Lab900TableTopContentDirective } from './directives/table-top-content.directive';
 import { Lab900TableCellComponent } from './components/table-cell/table-cell.component';
 import { Lab900TableCellValueComponent } from './components/table-cell-value/table-cell-value.component';
@@ -36,6 +37,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
     Lab900TableHeaderContentDirective,
     Lab900TableTopContentDirective,
     Lab900TableCustomCellDirective,
+    Lab900TableCustomHeaderCellDirective,
     Lab900TableFilterMenuComponent,
     Lab900TableHeaderComponent,
     Lab900TableCellComponent,
@@ -48,6 +50,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
     Lab900TableHeaderContentDirective,
     Lab900TableTopContentDirective,
     Lab900TableCustomCellDirective,
+    Lab900TableCustomHeaderCellDirective,
     Lab900TableFilterMenuComponent,
     Lab900TableHeaderComponent,
     Lab900TableCellComponent,

--- a/lib/src/public-api.ts
+++ b/lib/src/public-api.ts
@@ -44,6 +44,7 @@ export * from './lib/table/components/table-cell/table-cell.component';
 export * from './lib/table/components/table-cell-value/table-cell-value.component';
 export * from './lib/table/directives/table-empty.directive';
 export * from './lib/table/directives/table-custom-cell.directive';
+export * from './lib/table/directives/table-custom-header-cell.directive';
 export * from './lib/table/directives/table-disabled.directive';
 export * from './lib/table/directives/table-header-content.directive';
 export * from './lib/table/directives/table-top-content.directive';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,7 +4,7 @@ import { showcaseUiNavItems } from './modules/showcase-ui/showcase-ui.nav-items'
 import { TranslateService } from '@ngx-translate/core';
 import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
-import { repository } from '../../package.json';
+import packageInfo from '../../package.json';
 import { MatDrawer, MatDrawerMode } from '@angular/material/sidenav';
 import { MediaChange, MediaObserver } from '@angular/flex-layout';
 import { NavigationEnd, Router } from '@angular/router';
@@ -20,7 +20,7 @@ import { SubscriptionBasedDirective } from './modules/shared/directives/subscrip
 export class AppComponent extends SubscriptionBasedDirective implements OnInit, OnDestroy {
   private unsub = new Subject<void>();
   public readonly languages = ['en', 'nl'];
-  public readonly gitUrl = repository;
+  public readonly gitUrl = packageInfo.repository;
   public readonly navItemsGroups: NavItemGroup[] = showcaseUiNavItems;
   public language = 'en';
   public sideNavMode: MatDrawerMode = 'side';

--- a/src/app/modules/showcase-ui/examples/table-example/table-example.component.scss
+++ b/src/app/modules/showcase-ui/examples/table-example/table-example.component.scss
@@ -8,3 +8,9 @@
     }
   }
 }
+
+.rainbow {
+  background-image: linear-gradient(to left, violet, indigo, blue, green, yellow, orange, red);
+  color: white;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+}

--- a/src/app/modules/showcase-ui/examples/table-example/table-example.component.ts
+++ b/src/app/modules/showcase-ui/examples/table-example/table-example.component.ts
@@ -32,6 +32,9 @@ import { ActionButton, Lab900Sort, Paging, TableCell } from '@lab900/ui';
         <mat-checkbox color="primary" [checked]="data.element?.active"></mat-checkbox>
       </div>
     </div>
+    <div *lab900TableCustomHeaderCell="let data">
+      <div *ngIf="data.cell.key === 'active'" class="rainbow">Active</div>
+    </div>
     <div *lab900TableEmpty>
       <div class="no-results">
         <p>No results template (can be anything)</p>
@@ -204,6 +207,7 @@ export class TableExampleComponent {
       key: 'active',
       label: 'Active',
       customCellContent: true,
+      customHeaderCell: true,
       cellClass: 'center-cell',
       columnOrder: 2,
     },

--- a/src/app/modules/showcase-ui/showcase-ui.constants.ts
+++ b/src/app/modules/showcase-ui/showcase-ui.constants.ts
@@ -1,9 +1,9 @@
 import { ShowcaseConfigModel } from '../shared/models/showcase-config.model';
-import { version } from 'lib/package.json';
+import packageInfo from 'lib/package.json';
 
 export const showcaseUiConfig: ShowcaseConfigModel = {
   title: 'ui.title',
   description: 'ui.description',
   icon: 'widgets',
-  version,
+  version: packageInfo.version,
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
     "module": "es2020",
     "moduleResolution": "node",
     "importHelpers": true,


### PR DESCRIPTION
<img width="829" alt="CleanShot 2021-12-09 at 11 08 26@2x" src="https://user-images.githubusercontent.com/67897574/145376472-e9365c48-1851-4728-bf49-ddfd9807bd80.png">
