### PR TITLE
Feature/table tabs

### DIFF
--- a/lib/src/lib/table/components/table-tabs/table-tabs.component.html
+++ b/lib/src/lib/table/components/table-tabs/table-tabs.component.html
@@ -1,0 +1,5 @@
+<nav *ngIf="tableTabs?.length" class="lab900-table-tabs">
+  <button class="tab {{ tab.id }}" *ngFor="let tab of tableTabs" [class.active]="activeTabId === tab?.id" (click)="changeTable(tab)">
+    <span class="label">{{ tab.label | translate }}</span>
+  </button>
+</nav>

--- a/lib/src/lib/table/components/table-tabs/table-tabs.component.scss
+++ b/lib/src/lib/table/components/table-tabs/table-tabs.component.scss
@@ -1,0 +1,38 @@
+.lab900-table-tabs {
+  position: relative;
+  z-index: 1;
+  white-space: nowrap;
+  display: flex;
+
+  button {
+    position: relative;
+    padding: 0 calc(2em + 4px) 0 1em;
+    cursor: pointer;
+    overflow: hidden;
+    border: 1px solid #dde6e9;
+    border-bottom: 0;
+    outline: 0;
+    border-top-right-radius: 26px;
+    border-top-left-radius: 4px;
+    display: flex;
+    align-items: center;
+    font-weight: bold;
+    height: 26px;
+
+    .label {
+      line-height: 36px;
+      display: block;
+      margin-right: 10px;
+      font-size: 12px;
+    }
+
+    &:not(:first-child) {
+      margin-left: -0.5em;
+    }
+
+    &.active {
+      background: #fff;
+      z-index: 2;
+    }
+  }
+}

--- a/lib/src/lib/table/components/table-tabs/table-tabs.component.ts
+++ b/lib/src/lib/table/components/table-tabs/table-tabs.component.ts
@@ -1,0 +1,23 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Lab900TableTab } from '../../models/table-tabs.model';
+
+@Component({
+  selector: 'lab900-table-tabs',
+  templateUrl: './table-tabs.component.html',
+  styleUrls: ['./table-tabs.component.scss'],
+})
+export class Lab900TableTabsComponent<T = string> {
+  @Input()
+  public tableTabs: Lab900TableTab<T>[];
+
+  @Input()
+  public activeTabId: T;
+
+  @Output()
+  public activeTabIdChange = new EventEmitter<T>();
+
+  public changeTable(table: Lab900TableTab<T>): void {
+    this.activeTabId = table.id;
+    this.activeTabIdChange.emit(table.id);
+  }
+}

--- a/lib/src/lib/table/components/table/table.component.html
+++ b/lib/src/lib/table/components/table/table.component.html
@@ -19,6 +19,12 @@
   <mat-progress-bar *ngIf="loading" mode="indeterminate"></mat-progress-bar>
 
   <div class="lab900-table-wrapper">
+    <lab900-table-tabs
+      *ngIf="tableTabs?.length"
+      [tableTabs]="tableTabs"
+      [activeTabId]="activeTabId || tableTabs[0].id"
+      (activeTabIdChange)="onActiveTabChange($event)"
+    ></lab900-table-tabs>
     <table
       mat-table
       cdkDropList

--- a/lib/src/lib/table/components/table/table.component.ts
+++ b/lib/src/lib/table/components/table/table.component.ts
@@ -59,7 +59,14 @@ export interface SelectableRowsOptions<T = any> {
   encapsulation: ViewEncapsulation.None,
 })
 export class Lab900TableComponent<T extends object = object, TabId = string> implements OnChanges, AfterContentInit {
-  @Input()
+  private originalCells?: TableCell<T>[];
+
+  @Input('tableCells')
+  private set tableCellsInput(cells: TableCell<T>[]) {
+    this.originalCells = cells;
+    this.tableCells = cells;
+  }
+
   public set tableCells(cells: TableCell<T>[]) {
     this._tableCells = cells.sort(Lab900TableComponent.reorderColumnsFn);
     this.reloadColumns();
@@ -205,7 +212,7 @@ export class Lab900TableComponent<T extends object = object, TabId = string> imp
   public preFooterTitle: string;
 
   @Input()
-  public tableTabs: Lab900TableTab<TabId>[];
+  public tableTabs: Lab900TableTab<TabId, T>[];
 
   @Input()
   public activeTabId: TabId;
@@ -356,6 +363,17 @@ export class Lab900TableComponent<T extends object = object, TabId = string> imp
   }
 
   public onActiveTabChange(id: TabId): void {
+    this.selection.clear();
+    const previousTableTab = this.tableTabs.find((t) => t.id === this.activeTabId);
+    const activeTableTab = this.tableTabs.find((t) => t.id === id);
+
+    if (activeTableTab?.tableCells?.length) {
+      this.tableCells = activeTableTab.tableCells;
+      // load the original tableCells if the new active tab hasn't got any specific table cells but the previous tab had
+    } else if (previousTableTab?.tableCells?.length && !activeTableTab?.tableCells?.length && this.originalCells?.length) {
+      this.tableCells = this.originalCells;
+    }
+
     this.activeTabId = id;
     this.activeTabIdChange.emit(id);
   }

--- a/lib/src/lib/table/components/table/table.component.ts
+++ b/lib/src/lib/table/components/table/table.component.ts
@@ -30,6 +30,7 @@ import { ThemePalette } from '@angular/material/core';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { Lab900Sort } from '../../models/table-sort.model';
 import { Lab900TableCustomHeaderCellDirective } from '../../directives/table-custom-header-cell.directive';
+import { Lab900TableTab } from '../../models/table-tabs.model';
 
 type propFunction<T, R = string> = (data: T) => R;
 
@@ -57,7 +58,7 @@ export interface SelectableRowsOptions<T = any> {
   styleUrls: ['./table.component.scss'],
   encapsulation: ViewEncapsulation.None,
 })
-export class Lab900TableComponent<T extends object = object> implements OnChanges, AfterContentInit {
+export class Lab900TableComponent<T extends object = object, TabId = string> implements OnChanges, AfterContentInit {
   @Input()
   public set tableCells(cells: TableCell<T>[]) {
     this._tableCells = cells.sort(Lab900TableComponent.reorderColumnsFn);
@@ -203,6 +204,15 @@ export class Lab900TableComponent<T extends object = object> implements OnChange
   @Input()
   public preFooterTitle: string;
 
+  @Input()
+  public tableTabs: Lab900TableTab<TabId>[];
+
+  @Input()
+  public activeTabId: TabId;
+
+  @Output()
+  public activeTabIdChange = new EventEmitter<TabId>();
+
   @Output()
   public readonly pageChange = new EventEmitter<PageEvent>();
 
@@ -268,11 +278,7 @@ export class Lab900TableComponent<T extends object = object> implements OnChange
     this.selection.toggle(row);
 
     if (this.selectAllCheckbox) {
-      if (this.selection.selected.length === this.data.length) {
-        this.selectAllCheckbox.checked = true;
-      } else {
-        this.selectAllCheckbox.checked = false;
-      }
+      this.selectAllCheckbox.checked = this.selection?.selected?.length === this.data?.length;
     }
 
     this.selectionChanged.emit(this.selection);
@@ -347,6 +353,11 @@ export class Lab900TableComponent<T extends object = object> implements OnChange
     this.tableCells = tableCells.sort(Lab900TableComponent.reorderColumnsFn);
     this.addColumnsToTable();
     this.tableCellsFiltered.emit(tableCells);
+  }
+
+  public onActiveTabChange(id: TabId): void {
+    this.activeTabId = id;
+    this.activeTabIdChange.emit(id);
   }
 
   private addColumnsToTable(): void {

--- a/lib/src/lib/table/components/table/table.component.ts
+++ b/lib/src/lib/table/components/table/table.component.ts
@@ -63,7 +63,7 @@ export class Lab900TableComponent<T extends object = object, TabId = string> imp
 
   @Input('tableCells')
   private set tableCellsInput(cells: TableCell<T>[]) {
-    this.originalCells = cells;
+    this.originalCells = [...cells];
     this.tableCells = cells;
   }
 

--- a/lib/src/lib/table/models/table-tabs.model.ts
+++ b/lib/src/lib/table/models/table-tabs.model.ts
@@ -1,5 +1,10 @@
-export interface Lab900TableTab<T = string> {
-  id: T;
+import { TableCell } from './table-cell.model';
+
+export interface Lab900TableTab<TabId = string, T extends object = object> {
+  id: TabId;
   label: string;
-  loading?: boolean;
+  /**
+   * Load a different config for a tab
+   */
+  tableCells?: TableCell<T>[];
 }

--- a/lib/src/lib/table/models/table-tabs.model.ts
+++ b/lib/src/lib/table/models/table-tabs.model.ts
@@ -1,0 +1,5 @@
+export interface Lab900TableTab<T = string> {
+  id: T;
+  label: string;
+  loading?: boolean;
+}

--- a/lib/src/lib/table/table.module.ts
+++ b/lib/src/lib/table/table.module.ts
@@ -28,6 +28,7 @@ import { Lab900TableTopContentDirective } from './directives/table-top-content.d
 import { Lab900TableCellComponent } from './components/table-cell/table-cell.component';
 import { Lab900TableCellValueComponent } from './components/table-cell-value/table-cell-value.component';
 import { DragDropModule } from '@angular/cdk/drag-drop';
+import { Lab900TableTabsComponent } from './components/table-tabs/table-tabs.component';
 
 @NgModule({
   declarations: [
@@ -42,6 +43,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
     Lab900TableHeaderComponent,
     Lab900TableCellComponent,
     Lab900TableCellValueComponent,
+    Lab900TableTabsComponent,
   ],
   exports: [
     Lab900TableComponent,
@@ -55,6 +57,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
     Lab900TableHeaderComponent,
     Lab900TableCellComponent,
     Lab900TableCellValueComponent,
+    Lab900TableTabsComponent,
   ],
   imports: [
     CommonModule,

--- a/lib/src/public-api.ts
+++ b/lib/src/public-api.ts
@@ -42,6 +42,7 @@ export * from './lib/table/components/table-header/lab900-table-header.component
 export * from './lib/table/components/table-filter-menu/table-filter-menu.component';
 export * from './lib/table/components/table-cell/table-cell.component';
 export * from './lib/table/components/table-cell-value/table-cell-value.component';
+export * from './lib/table/components/table-tabs/table-tabs.component';
 export * from './lib/table/directives/table-empty.directive';
 export * from './lib/table/directives/table-custom-cell.directive';
 export * from './lib/table/directives/table-custom-header-cell.directive';
@@ -51,6 +52,7 @@ export * from './lib/table/directives/table-top-content.directive';
 export * from './lib/table/models/table-cell.model';
 export * from './lib/table/models/table-cell-tooltip.model';
 export * from './lib/table/models/table-sort.model';
+export * from './lib/table/models/table-tabs.model';
 
 // page header
 export * from './lib/page-header/page-header.module';

--- a/src/app/modules/showcase-ui/examples/table-example/table-tabs-example.component.ts
+++ b/src/app/modules/showcase-ui/examples/table-example/table-tabs-example.component.ts
@@ -39,6 +39,39 @@ const mockDataC: any[] = [
   },
 ];
 
+const tableCells: TableCell[] = [
+  {
+    key: 'id',
+    label: 'ID',
+  },
+  {
+    key: 'name',
+    label: 'Name',
+  },
+];
+
+const tableCellsAlt: TableCell[] = [
+  {
+    key: 'id',
+    label: 'ID',
+  },
+  {
+    key: 'name',
+    label: 'Name',
+  },
+  {
+    key: 'alt',
+    label: 'Tab specific column',
+  },
+];
+
+const tableCellsAlt2: TableCell[] = [
+  {
+    key: 'name',
+    label: 'Name',
+  },
+];
+
 @Component({
   selector: 'lab900-table-tabs-example',
   template: `<lab900-table [tableCells]="tableCells" [data]="activeData" [tableTabs]="tabs" (activeTabIdChange)="switchData($event)">
@@ -49,10 +82,11 @@ export class TableTabsExampleComponent {
   private table: Lab900TableComponent;
 
   public activeData: any[] = mockDataA;
+
   public tabs: Lab900TableTab<'a' | 'b' | 'c'>[] = [
     { id: 'a', label: 'tab A' },
-    { id: 'b', label: 'tab B' },
-    { id: 'c', label: 'tab C' },
+    { id: 'b', label: 'tab B', tableCells: tableCellsAlt },
+    { id: 'c', label: 'tab C', tableCells: tableCellsAlt2 },
   ];
 
   public tableCells: TableCell[] = [

--- a/src/app/modules/showcase-ui/examples/table-example/table-tabs-example.component.ts
+++ b/src/app/modules/showcase-ui/examples/table-example/table-tabs-example.component.ts
@@ -1,6 +1,5 @@
 import { Component, ViewChild } from '@angular/core';
-import { Lab900TableComponent, TableCell } from '@lab900/ui';
-import { Lab900TableTab } from '../../../../../../dist/@lab900/ui/lib/table/models/table-tabs.model';
+import { Lab900TableComponent, TableCell, Lab900TableTab } from '@lab900/ui';
 
 const mockDataA: any[] = [
   {

--- a/src/app/modules/showcase-ui/examples/table-example/table-tabs-example.component.ts
+++ b/src/app/modules/showcase-ui/examples/table-example/table-tabs-example.component.ts
@@ -1,0 +1,82 @@
+import { Component, ViewChild } from '@angular/core';
+import { Lab900TableComponent, TableCell } from '@lab900/ui';
+import { Lab900TableTab } from '../../../../../../dist/@lab900/ui/lib/table/models/table-tabs.model';
+
+const mockDataA: any[] = [
+  {
+    id: 1,
+    name: 'John',
+  },
+  {
+    id: 2,
+    name: 'Lucie',
+  },
+];
+
+const mockDataB: any[] = [
+  {
+    id: 3,
+    name: 'Rob',
+  },
+  {
+    id: 4,
+    name: 'Sarah',
+  },
+];
+
+const mockDataC: any[] = [
+  {
+    id: 5,
+    name: 'Max',
+  },
+  {
+    id: 6,
+    name: 'Jane',
+  },
+  {
+    id: 7,
+    name: 'Oliver',
+  },
+];
+
+@Component({
+  selector: 'lab900-table-tabs-example',
+  template: `<lab900-table [tableCells]="tableCells" [data]="activeData" [tableTabs]="tabs" (activeTabIdChange)="switchData($event)">
+  </lab900-table>`,
+})
+export class TableTabsExampleComponent {
+  @ViewChild(Lab900TableComponent)
+  private table: Lab900TableComponent;
+
+  public activeData: any[] = mockDataA;
+  public tabs: Lab900TableTab<'a' | 'b' | 'c'>[] = [
+    { id: 'a', label: 'tab A' },
+    { id: 'b', label: 'tab B' },
+    { id: 'c', label: 'tab C' },
+  ];
+
+  public tableCells: TableCell[] = [
+    {
+      key: 'id',
+      label: 'ID',
+    },
+    {
+      key: 'name',
+      label: 'Name',
+    },
+  ];
+
+  public switchData(tabId: 'a' | 'b' | 'c'): void {
+    switch (tabId) {
+      case 'a':
+        this.activeData = mockDataA;
+        break;
+      case 'b':
+        this.activeData = mockDataB;
+        break;
+      case 'c':
+        this.activeData = mockDataC;
+        break;
+    }
+  }
+}

--- a/src/app/modules/showcase-ui/showcase-ui-routing.module.ts
+++ b/src/app/modules/showcase-ui/showcase-ui-routing.module.ts
@@ -16,6 +16,7 @@ import { showcaseUiConfig } from './showcase-ui.constants';
 import { showcaseUiNavItems } from './showcase-ui.nav-items';
 import { MarkdownPageComponent } from '../shared/components/markdown-page/markdown-page.component';
 import { TableDragAndDropExampleComponent } from './examples/table-example/table-drag-and-drop-example.component';
+import { TableTabsExampleComponent } from './examples/table-example/table-tabs-example.component';
 
 const routes: Routes = [
   {
@@ -36,6 +37,7 @@ const routes: Routes = [
   new ShowcaseRoute('table', 'Table', [
     new ShowcaseExample(TableExampleComponent, 'Table'),
     new ShowcaseExample(TableDragAndDropExampleComponent, 'Table with re-arrangeable rows'),
+    new ShowcaseExample(TableTabsExampleComponent, 'Table with different tabs'),
   ]),
   new ShowcaseRoute('page-header', 'Page header', [
     new ShowcaseExample(PageHeaderParamsExampleComponent, 'Page header from request params'),

--- a/src/app/modules/showcase-ui/showcase-ui.module.ts
+++ b/src/app/modules/showcase-ui/showcase-ui.module.ts
@@ -24,6 +24,7 @@ import { ButtonExampleComponent } from './examples/button-example/button-example
 import { Lab900ButtonModule } from '@lab900/ui';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { TableDragAndDropExampleComponent } from './examples/table-example/table-drag-and-drop-example.component';
+import { TableTabsExampleComponent } from './examples/table-example/table-tabs-example.component';
 
 const examples = [
   SharingExampleComponent,
@@ -34,6 +35,7 @@ const examples = [
   PageHeaderParamsExampleComponent,
   TableExampleComponent,
   TableDragAndDropExampleComponent,
+  TableTabsExampleComponent,
   MergerExampleComponent,
   CustomExampleComponent,
   ButtonExampleComponent,


### PR DESCRIPTION
## Purpose
Tables with different tabs

## Approach
- Copied the report tabs from Euroports and made it a bit more generic
- Via the Output `activeTabIdChange` you can update the table data
- In the tab config you can specify different TableCells per tab (not required).

![Schermafbeelding 2022-02-28 om 10 15 10](https://user-images.githubusercontent.com/13655941/155963022-bc9c3e3a-9b18-40f2-a775-6f60d7fa4dba.png)

