### PR TITLE
Added the option to display content in the left side of the table footer

### DIFF
--- a/lib/src/lib/table/components/table/table.component.html
+++ b/lib/src/lib/table/components/table/table.component.html
@@ -152,21 +152,30 @@
     </ng-container>
   </div>
 
-  <div class="lab900-table__footer" *ngIf="tableFooterActions?.length || (data?.length && paging)">
-    <div>
-      <div class="lab900-table__footer__actions" *ngIf="tableFooterActions?.length">
-        <lab900-action-button *ngFor="let action of tableFooterActions" [action]="action"></lab900-action-button>
-      </div>
+  <div
+    class="lab900-table__footer"
+    [class.left-content]="footerLeftContent"
+    *ngIf="footerLeftContent || tableFooterActions?.length || (data?.length && paging)"
+  >
+    <div class="lab900-table__footer__left" *ngIf="footerLeftContent">
+      <ng-container *ngTemplateOutlet="footerLeftContent"></ng-container>
     </div>
-    <mat-paginator
-      *ngIf="data?.length && paging"
-      [hidePageSize]="pageSizeConfig.hidePageSize"
-      [pageSizeOptions]="pageSizeConfig.pageSizeOptions"
-      [length]="paging.totalItems"
-      [pageSize]="paging.pageSize"
-      [pageIndex]="paging.pageIndex"
-      (page)="pageChange.emit($event)"
-    ></mat-paginator>
+    <div class="lab900-table__footer__right">
+      <div>
+        <div class="lab900-table__footer__actions" *ngIf="tableFooterActions?.length">
+          <lab900-action-button *ngFor="let action of tableFooterActions" [action]="action"></lab900-action-button>
+        </div>
+      </div>
+      <mat-paginator
+        *ngIf="data?.length && paging"
+        [hidePageSize]="pageSizeConfig.hidePageSize"
+        [pageSizeOptions]="pageSizeConfig.pageSizeOptions"
+        [length]="paging.totalItems"
+        [pageSize]="paging.pageSize"
+        [pageIndex]="paging.pageIndex"
+        (page)="pageChange.emit($event)"
+      ></mat-paginator>
+    </div>
   </div>
 
   <div *ngIf="disabled">

--- a/lib/src/lib/table/components/table/table.component.scss
+++ b/lib/src/lib/table/components/table/table.component.scss
@@ -68,11 +68,24 @@
   &__footer {
     @media screen and (min-width: 600px) {
       display: flex;
-      align-items: center;
-    }
 
-    > div {
-      flex: 1;
+      &.left-content {
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      &:not(.left-content) {
+        justify-content: flex-end;
+      }
+
+      &__right {
+        display: flex;
+        align-items: center;
+
+        > div {
+          flex: 1;
+        }
+      }
     }
 
     &__actions {

--- a/lib/src/lib/table/components/table/table.component.ts
+++ b/lib/src/lib/table/components/table/table.component.ts
@@ -31,6 +31,7 @@ import { MatCheckbox } from '@angular/material/checkbox';
 import { Lab900Sort } from '../../models/table-sort.model';
 import { Lab900TableCustomHeaderCellDirective } from '../../directives/table-custom-header-cell.directive';
 import { Lab900TableTab } from '../../models/table-tabs.model';
+import { Lab900TableLeftFooterDirective } from '../../directives/table-left-footer.directive';
 
 type propFunction<T, R = string> = (data: T) => R;
 
@@ -252,6 +253,9 @@ export class Lab900TableComponent<T extends object = object, TabId = string> imp
 
   @ContentChild(Lab900TableCustomHeaderCellDirective, { read: TemplateRef })
   public customHeaderCell?: Lab900TableCustomHeaderCellDirective;
+
+  @ContentChild(Lab900TableLeftFooterDirective, { read: TemplateRef })
+  public footerLeftContent?: Lab900TableLeftFooterDirective;
 
   public displayedColumns: string[] = [];
 

--- a/lib/src/lib/table/components/table/table.component.ts
+++ b/lib/src/lib/table/components/table/table.component.ts
@@ -63,7 +63,7 @@ export class Lab900TableComponent<T extends object = object, TabId = string> imp
   private originalCells?: TableCell<T>[];
 
   @Input('tableCells')
-  private set tableCellsInput(cells: TableCell<T>[]) {
+  public set tableCellsInput(cells: TableCell<T>[]) {
     this.originalCells = [...cells];
     this.tableCells = cells;
   }

--- a/lib/src/lib/table/directives/table-left-footer.directive.ts
+++ b/lib/src/lib/table/directives/table-left-footer.directive.ts
@@ -1,0 +1,7 @@
+import { Directive } from '@angular/core';
+
+@Directive({
+  // tslint:disable-next-line:directive-selector
+  selector: '[lab900TableLeftFooter]',
+})
+export class Lab900TableLeftFooterDirective {}

--- a/lib/src/lib/table/table.module.ts
+++ b/lib/src/lib/table/table.module.ts
@@ -29,6 +29,7 @@ import { Lab900TableCellComponent } from './components/table-cell/table-cell.com
 import { Lab900TableCellValueComponent } from './components/table-cell-value/table-cell-value.component';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { Lab900TableTabsComponent } from './components/table-tabs/table-tabs.component';
+import { Lab900TableLeftFooterDirective } from './directives/table-left-footer.directive';
 
 @NgModule({
   declarations: [
@@ -44,6 +45,7 @@ import { Lab900TableTabsComponent } from './components/table-tabs/table-tabs.com
     Lab900TableCellComponent,
     Lab900TableCellValueComponent,
     Lab900TableTabsComponent,
+    Lab900TableLeftFooterDirective,
   ],
   exports: [
     Lab900TableComponent,
@@ -58,6 +60,7 @@ import { Lab900TableTabsComponent } from './components/table-tabs/table-tabs.com
     Lab900TableCellComponent,
     Lab900TableCellValueComponent,
     Lab900TableTabsComponent,
+    Lab900TableLeftFooterDirective,
   ],
   imports: [
     CommonModule,

--- a/lib/src/public-api.ts
+++ b/lib/src/public-api.ts
@@ -49,6 +49,7 @@ export * from './lib/table/directives/table-custom-header-cell.directive';
 export * from './lib/table/directives/table-disabled.directive';
 export * from './lib/table/directives/table-header-content.directive';
 export * from './lib/table/directives/table-top-content.directive';
+export * from './lib/table/directives/table-left-footer.directive';
 export * from './lib/table/models/table-cell.model';
 export * from './lib/table/models/table-cell-tooltip.model';
 export * from './lib/table/models/table-sort.model';

--- a/src/app/modules/showcase-ui/examples/table-example/table-example.component.ts
+++ b/src/app/modules/showcase-ui/examples/table-example/table-example.component.ts
@@ -40,6 +40,7 @@ import { ActionButton, Lab900Sort, Paging, TableCell } from '@lab900/ui';
         <p>No results template (can be anything)</p>
       </div>
     </div>
+    <div *lab900TableLeftFooter>Test content left side of footer</div>
   </lab900-table>`,
   styleUrls: ['table-example.component.scss'],
 })


### PR DESCRIPTION
## Purpose 
Have the option to show something in the left side of the table footer.

## Approach
Created a new `lab900TableLeftFooter` directive that can be used inside the table