### PR TITLE
fix(18.0.10): sorting icon in table header not updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,24 @@
 # Changelog
 
-## 18.0.9
+## 18.0.10
+- fix: sorting arrows in table not updating correctly
 
+## 18.0.9
 - fix: table tooltip translations
 
 ## 18.0.7/18.0.8
-
 - fix: issues with structuredClone
 
 ## 18.0.6
-
 - fix: table cell value states
 
 ## 18.0.5
-
 - fix hideSelectableRow
 
 ## 18.0.4
-
 - fix issues with navigation table cells with some rows not having editable cells
 
 ## 18.0.3
-
 - Upgrade to Angular 18
 - More components are using Signals
 
@@ -34,26 +31,21 @@
 - fix issues with navigation table cells with some rows not having editable cells
 
 ## 17.0.2
-
 - Fix required type in Lab900ButtonComponent
 
 ## 17.0.1
-
 - Fix click event on Lab900ActionButtonComponent
 
 ## 17.0.0
-
 Upgrade to Angular 17
 
 ### Breaking changes
 
 #### The last modules have been removed:
-
 - `Lab900MergerModule` is removed. Import the standalone component `Lab900MergerComponent` instead.
 - `DialogModule` is removed. Import any of the standalone components `ConfirmationDialogComponent`, `AlertDialogComponent` instead.
 - `Lab900ButtonModule` is removed. Import any of the standalone componenst `Lab900ButtonComponent`, `Lab900ActionButtonToggleComponent`, `Lab900ActionButtonMenuComponent`, `Lab900ActionButtonComponent` instead.
 - `Lab900DataListModule` is removed. Import the standalone component `Lab900DataListComponent` instead.
 
 ## older version
-
 Sorry no changelog available :(

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/ui",
-  "version": "18.0.9",
+  "version": "18.0.10",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {

--- a/lib/src/lib/table/components/table-cell-inner/table-cell-inner.component.ts
+++ b/lib/src/lib/table/components/table-cell-inner/table-cell-inner.component.ts
@@ -48,7 +48,7 @@ export class TableCellInnerComponent<T = any> {
     const dataUniqueId = cell.key + '_' + this.rowIndex();
 
     return (
-      this.tableService.inlineEditingCellkey() === dataUniqueId &&
+      this.tableService.inlineEditingCellKey() === dataUniqueId &&
       cell.cellEditor &&
       !cell.cellEditorOptions?.disabled?.(this.rowValue())
     );

--- a/lib/src/lib/table/services/table.service.ts
+++ b/lib/src/lib/table/services/table.service.ts
@@ -5,7 +5,7 @@ import { Lab900Sort } from '../models/table-sort.model';
 
 @Injectable()
 export class Lab900TableService<T extends object = object, TabId = string> {
-  public readonly inlineEditingCellkey = signal<string | undefined>(undefined);
+  public readonly inlineEditingCellKey = signal<string | undefined>(undefined);
 
   private readonly _columns = signal<TableCell<T>[]>([]);
 
@@ -39,7 +39,7 @@ export class Lab900TableService<T extends object = object, TabId = string> {
   }
 
   public updateColumns(columns: TableCell<T>[] | null): void {
-    this._columns.set(columns ?? []);
+    this._columns.set([...(columns ?? [])]);
   }
 
   public updateTabId(tabId: TabId | null): void {
@@ -51,11 +51,11 @@ export class Lab900TableService<T extends object = object, TabId = string> {
   }
 
   public updateTabs(tabs: Lab900TableTab<TabId, T>[] | null): void {
-    this._tabs.set(tabs ?? []);
+    this._tabs.set([...(tabs ?? [])]);
   }
 
   public updateSorting(sort: Lab900Sort[] | undefined): void {
-    this.sort.set(sort);
+    this.sort.set(sort ? [...sort] : undefined);
   }
 
   public updateColumnSorting(
@@ -77,7 +77,7 @@ export class Lab900TableService<T extends object = object, TabId = string> {
         } else {
           sort.push({ id: sortKey, direction: 'asc' });
         }
-        return sort;
+        return [...sort];
       } else {
         const inCurrent = sort.find(s => s.id === sortKey);
         return [
@@ -92,10 +92,10 @@ export class Lab900TableService<T extends object = object, TabId = string> {
   }
 
   public startInlineEditing(cellKey: string): void {
-    this.inlineEditingCellkey.set(cellKey);
+    this.inlineEditingCellKey.set(cellKey);
   }
 
   public closeInlineEditing(): void {
-    this.inlineEditingCellkey.set(undefined);
+    this.inlineEditingCellKey.set(undefined);
   }
 }


### PR DESCRIPTION
### Description 
When updating a signal that contains a list, you need to take the destructured copy, otherwise the signal will not be marked as dirty for change detection!

### Example:
```typescript
this.yourListSignal.update((current) => {
  current.sort();
  return [...current];
});
```