### PR TITLE
Feature/table performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 18.1.0
+## 18.1.1
 - deferred table cells for better performance
 
 ## 18.0.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 18.1.0
+- deferred table cells for better performance
+
 ## 18.0.12
 - fix: nav-item with children where throwing NG0953 errors
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/ui",
-  "version": "18.1.0",
+  "version": "18.1.1",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/ui",
-  "version": "18.0.12",
+  "version": "18.1.0",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {

--- a/lib/src/lib/table/components/table-cell-inner/table-cell-inner.component.html
+++ b/lib/src/lib/table/components/table-cell-inner/table-cell-inner.component.html
@@ -14,7 +14,7 @@
   } @else {
     <ng-container
       *ngComponentOutlet="
-        cell().cellRenderer || defaultCellRenderer;
+        cellTemplate();
         inputs: {
           data: rowValue(),
           columnConfig: cell(),

--- a/lib/src/lib/table/components/table-cell-inner/table-cell-inner.component.ts
+++ b/lib/src/lib/table/components/table-cell-inner/table-cell-inner.component.ts
@@ -6,7 +6,6 @@ import {
   ElementRef,
   inject,
   input,
-  NgZone,
   output,
   ViewEncapsulation,
 } from '@angular/core';
@@ -26,7 +25,6 @@ import { NgComponentOutlet } from '@angular/common';
 export class TableCellInnerComponent<T = any> {
   private readonly tableService = inject(Lab900TableService);
   private readonly elRef = inject(ElementRef);
-  private readonly ngZone = inject(NgZone);
 
   public readonly defaultCellRenderer = DefaultCellRendererComponent;
 
@@ -62,27 +60,25 @@ export class TableCellInnerComponent<T = any> {
 
   public constructor() {
     effect(() => {
-      this.ngZone.runOutsideAngular(() => {
-        const parentElm = this.elRef?.nativeElement?.parentElement;
-        if (parentElm) {
-          if (this.isEditing()) {
-            parentElm.classList.add('edit-mode');
-          } else {
-            parentElm.classList.remove('edit-mode');
-          }
-          if (this.canEdit()) {
-            parentElm.classList.add('editable');
-          } else {
-            parentElm.classList.remove('editable');
-          }
-          parentElm.tabIndex = this.canEdit() ? 0 : -1;
-          if (this.cellClasses()) {
-            parentElm.classList.remove(...this.previousClasses);
-            parentElm.classList.add(...this.cellClasses());
-            this.previousClasses = this.cellClasses();
-          }
+      const parentElm = this.elRef?.nativeElement?.parentElement;
+      if (parentElm) {
+        if (this.isEditing()) {
+          parentElm.classList.add('edit-mode');
+        } else {
+          parentElm.classList.remove('edit-mode');
         }
-      });
+        if (this.canEdit()) {
+          parentElm.classList.add('editable');
+        } else {
+          parentElm.classList.remove('editable');
+        }
+        parentElm.tabIndex = this.canEdit() ? 0 : -1;
+        if (this.cellClasses()) {
+          parentElm.classList.remove(...this.previousClasses);
+          parentElm.classList.add(...this.cellClasses());
+          this.previousClasses = this.cellClasses();
+        }
+      }
     });
   }
 

--- a/lib/src/lib/table/components/table-cell-inner/table-cell-inner.component.ts
+++ b/lib/src/lib/table/components/table-cell-inner/table-cell-inner.component.ts
@@ -26,14 +26,14 @@ export class TableCellInnerComponent<T = any> {
   private readonly tableService = inject(Lab900TableService);
   private readonly elRef = inject(ElementRef);
 
-  public readonly defaultCellRenderer = DefaultCellRendererComponent;
-
   public readonly cell = input.required<TableCell<T>>();
   public readonly rowValue = input.required<T>();
   public readonly rowIndex = input.required<number>();
   public readonly valueChanged = output<CellValueChangeEvent<T>>();
 
   private previousClasses: string[] = [];
+
+  protected readonly cellTemplate = computed(() => this.cell().cellRenderer ?? DefaultCellRendererComponent);
 
   public readonly canEdit = computed(() => {
     return (

--- a/lib/src/lib/table/components/table-cell-inner/table-cell-inner.component.ts
+++ b/lib/src/lib/table/components/table-cell-inner/table-cell-inner.component.ts
@@ -6,6 +6,7 @@ import {
   ElementRef,
   inject,
   input,
+  NgZone,
   output,
   ViewEncapsulation,
 } from '@angular/core';
@@ -25,6 +26,7 @@ import { NgComponentOutlet } from '@angular/common';
 export class TableCellInnerComponent<T = any> {
   private readonly tableService = inject(Lab900TableService);
   private readonly elRef = inject(ElementRef);
+  private readonly ngZone = inject(NgZone);
 
   public readonly defaultCellRenderer = DefaultCellRendererComponent;
 
@@ -60,25 +62,27 @@ export class TableCellInnerComponent<T = any> {
 
   public constructor() {
     effect(() => {
-      const parentElm = this.elRef?.nativeElement?.parentElement;
-      if (parentElm) {
-        if (this.isEditing()) {
-          parentElm.classList.add('edit-mode');
-        } else {
-          parentElm.classList.remove('edit-mode');
+      this.ngZone.runOutsideAngular(() => {
+        const parentElm = this.elRef?.nativeElement?.parentElement;
+        if (parentElm) {
+          if (this.isEditing()) {
+            parentElm.classList.add('edit-mode');
+          } else {
+            parentElm.classList.remove('edit-mode');
+          }
+          if (this.canEdit()) {
+            parentElm.classList.add('editable');
+          } else {
+            parentElm.classList.remove('editable');
+          }
+          parentElm.tabIndex = this.canEdit() ? 0 : -1;
+          if (this.cellClasses()) {
+            parentElm.classList.remove(...this.previousClasses);
+            parentElm.classList.add(...this.cellClasses());
+            this.previousClasses = this.cellClasses();
+          }
         }
-        if (this.canEdit()) {
-          parentElm.classList.add('editable');
-        } else {
-          parentElm.classList.remove('editable');
-        }
-        parentElm.tabIndex = this.canEdit() ? 0 : -1;
-        if (this.cellClasses()) {
-          parentElm.classList.remove(...this.previousClasses);
-          parentElm.classList.add(...this.cellClasses());
-          this.previousClasses = this.cellClasses();
-        }
-      }
+      });
     });
   }
 

--- a/lib/src/lib/table/components/table-cell/table-cell.component.html
+++ b/lib/src/lib/table/components/table-cell/table-cell.component.html
@@ -11,27 +11,33 @@
     [matTooltipPosition]="cell().cellHeaderTooltipPosition || 'above'"
     [style.width]="columnWidth()"
     [style.max-width]="columnMaxWidth()">
-    <ng-container
-      *ngComponentOutlet="
-        cell().headerRenderer || defaultHeaderRenderer;
-        inputs: { columnConfig: cell(), disableSort: disableSort() }
-      " />
+    @defer (on viewport) {
+      <ng-container
+        *ngComponentOutlet="
+          cell().headerRenderer || defaultHeaderRenderer;
+          inputs: { columnConfig: cell(), disableSort: disableSort() }
+        " />
+    } @placeholder {
+      <div class="lab900-deferred-cell-placeholder"></div>
+    }
   </th>
   <td
     mat-cell
     *matCellDef="let element; let rowIndex = dataIndex"
     [style.width]="columnWidth()"
     [style.max-width]="columnMaxWidth()"
-    lab900TableCellEvents
-    [cellData]="element"
-    [rowIndex]="rowIndex"
-    [cell]="cell()"
     class="lab900-td">
-    <lab900-table-cell-inner
-      [cell]="cell()"
-      [rowValue]="element"
-      [rowIndex]="rowIndex"
-      (valueChanged)="valueChanged.emit($event)" />
+    @defer (on viewport) {
+      <lab900-table-cell-inner
+        [cell]="cell()"
+        lab900TableCellEvents
+        [cellData]="element"
+        [rowValue]="element"
+        [rowIndex]="rowIndex"
+        (valueChanged)="valueChanged.emit($event)" />
+    } @placeholder {
+      <div class="lab900-deferred-cell-placeholder"></div>
+    }
   </td>
   @if (showFooterCell()) {
     <td mat-footer-cell *matFooterCellDef [innerHtml]="cellFooter()" [ngClass]="cell().footerCellClass"></td>

--- a/lib/src/lib/table/components/table-cell/table-cell.component.html
+++ b/lib/src/lib/table/components/table-cell/table-cell.component.html
@@ -11,12 +11,9 @@
     [matTooltipPosition]="cell().cellHeaderTooltipPosition || 'above'"
     [style.width]="columnWidth()"
     [style.max-width]="columnMaxWidth()">
-    @defer (on viewport) {
+    @defer (on viewport; prefetch on idle) {
       <ng-container
-        *ngComponentOutlet="
-          cell().headerRenderer || defaultHeaderRenderer;
-          inputs: { columnConfig: cell(), disableSort: disableSort() }
-        " />
+        *ngComponentOutlet="columnHeaderTemplate(); inputs: { columnConfig: cell(), disableSort: disableSort() }" />
     } @placeholder {
       <div class="lab900-deferred-cell-placeholder"></div>
     }
@@ -27,7 +24,7 @@
     [style.width]="columnWidth()"
     [style.max-width]="columnMaxWidth()"
     class="lab900-td">
-    @defer (on viewport) {
+    @defer (on viewport; prefetch on idle) {
       <lab900-table-cell-inner
         [cell]="cell()"
         lab900TableCellEvents

--- a/lib/src/lib/table/components/table-cell/table-cell.component.ts
+++ b/lib/src/lib/table/components/table-cell/table-cell.component.ts
@@ -65,6 +65,10 @@ export class Lab900TableCellComponent<T = any> implements OnDestroy, OnInit {
     return this.cell().cellMaxWidth ?? this.maxColumnWidthFromTable();
   });
 
+  public readonly columnHeaderTemplate = computed(() => {
+    return this.cell().headerRenderer ?? this.defaultHeaderRenderer;
+  });
+
   public readonly columnWidth = computed(() => {
     if (this.cell().width === '*') {
       return '100%';

--- a/lib/src/lib/table/components/table-cell/table-cell.component.ts
+++ b/lib/src/lib/table/components/table-cell/table-cell.component.ts
@@ -60,6 +60,7 @@ export class Lab900TableCellComponent<T = any> implements OnDestroy, OnInit {
   public readonly disableSort = input<boolean>(false);
   public readonly maxColumnWidthFromTable = input<string | undefined>(undefined);
   public readonly showFooterCell = input<boolean>(false);
+  public readonly deferred = input<boolean>(false);
 
   public readonly columnMaxWidth = computed(() => {
     return this.cell().cellMaxWidth ?? this.maxColumnWidthFromTable();

--- a/lib/src/lib/table/components/table-cell/table-cell.component.ts
+++ b/lib/src/lib/table/components/table-cell/table-cell.component.ts
@@ -60,7 +60,6 @@ export class Lab900TableCellComponent<T = any> implements OnDestroy, OnInit {
   public readonly disableSort = input<boolean>(false);
   public readonly maxColumnWidthFromTable = input<string | undefined>(undefined);
   public readonly showFooterCell = input<boolean>(false);
-  public readonly deferred = input<boolean>(false);
 
   public readonly columnMaxWidth = computed(() => {
     return this.cell().cellMaxWidth ?? this.maxColumnWidthFromTable();

--- a/lib/src/lib/table/components/table/table.component.html
+++ b/lib/src/lib/table/components/table/table.component.html
@@ -13,140 +13,143 @@
     @if (tabs().length) {
       <lab900-table-tabs [tableTabs]="tabs()" [activeTabId]="tabId()" (activeTabIdChange)="onActiveTabChange($event)" />
     }
-    @if (loading()) {
-      <mat-progress-bar mode="indeterminate" />
-    }
-    <div class="lab900-table-wrapper" [class.sticky-header]="stickyHeader()">
-      <table
-        mat-table
-        cdkDropList
-        [cdkDropListDisabled]="!draggableRows()"
-        class="mat-elevation-z0"
-        [multiTemplateDataRows]="true"
-        [trackBy]="trackByTableFn()"
-        [dataSource]="publicData()"
-        (cdkDropListDropped)="tableRowOrderChange.emit($event)"
-        [class.has-back-actions]="tableActionsBack()?.length"
-        [class.has-front-actions]="tableActionsFront()?.length">
-        @if (selectableRows()?.enabled) {
-          <lab900-table-cell-select
-            [showFooter]="showCellFooters()"
-            [options]="selectableRows()"
-            [selection]="selection()"
-            (selectAll)="handleSelectAll($event)"
-            (selectRow)="handleSelectRow($event)" />
-        }
-        @for (column of visibleColumns(); track column.key) {
-          <lab900-table-cell
-            [cell]="column"
-            [disableSort]="disableSort()"
-            [maxColumnWidthFromTable]="maxColumnWidth()"
-            (headerClick)="handleHeaderClick($event)"
-            [data]="publicData()"
-            [showFooterCell]="showCellFooters()"
-            (valueChanged)="cellValueChanged.emit($event)" />
-        }
-        <ng-container matColumnDef="actions-front">
-          <th mat-header-cell *matHeaderCellDef></th>
-          <td mat-cell *matCellDef="let element; let index = index" (click)="$event.stopPropagation()">
-            @if (tableActionsFront()?.length) {
-              <div class="table-row-actions-front">
-                @for (action of tableActionsFront(); track action.label) {
-                  <lab900-action-button
-                    [data]="element"
-                    [action]="action"
-                    cdkDragHandle
-                    [cdkDragHandleDisabled]="!action?.draggable" />
-                }
-              </div>
-            }
-          </td>
-          @if (showCellFooters()) {
-            <td mat-footer-cell *matFooterCellDef></td>
-          }
-        </ng-container>
-        <ng-container matColumnDef="actions-back" stickyEnd>
-          <th mat-header-cell *matHeaderCellDef></th>
-          <td mat-cell *matCellDef="let element; let index = index" (click)="$event.stopPropagation()">
-            @if (tableActionsBack()?.length) {
-              <div class="table-row-actions-back">
-                @for (action of tableActionsBack(); track action.label) {
-                  <lab900-action-button
-                    [data]="element"
-                    [action]="action"
-                    cdkDragHandle
-                    [cdkDragHandleDisabled]="!action?.draggable" />
-                }
-              </div>
-            }
-          </td>
-          @if (showCellFooters()) {
-            <td mat-footer-cell *matFooterCellDef></td>
-          }
-        </ng-container>
-        @if (displayedColumns()) {
-          <!-- header row -->
-          <tr mat-header-row *matHeaderRowDef="displayedColumns(); sticky: stickyHeader"></tr>
-          <!-- content rows -->
-          <tr
-            mat-row
-            *matRowDef="let row; columns: displayedColumns(); let i = dataIndex"
-            [ngClass]="getRowClasses(row, i)"
-            [class.lab900-row-selected]="isRowSelected(row)"
-            [style.background-color]="getRowColor(row)"
-            (click)="handleRowClick($event, row, i)"
-            cdkDrag
-            [cdkDragDisabled]="!draggableRows()"></tr>
-          @if (showCellFooters()) {
-            <div>
-              <!-- pre footer row -->
-              @if (preFooterTitle(); as preFooterTitle) {
-                <ng-container matColumnDef="preFooterTitle">
-                  <td
-                    mat-footer-cell
-                    *matFooterCellDef
-                    [attr.colspan]="visibleColumns().length + 1"
-                    class="lab900-table__pre-footer-title-cell">
-                    {{ preFooterTitle | translate }}
-                  </td>
-                </ng-container>
-                <tr
-                  [hidden]="!publicData()?.length"
-                  mat-footer-row
-                  *matFooterRowDef="['preFooterTitle']"
-                  class="lab900-table__pre-footer-title-row"></tr>
-              }
-              <!-- footer row -->
-              <tr [hidden]="!publicData()?.length" mat-footer-row *matFooterRowDef="displayedColumns()"></tr>
-            </div>
-          }
-          <!-- drag placeholder -->
-          @if (draggableRows()) {
-            <div *cdkDragPlaceholder></div>
-          }
-        }
-      </table>
-    </div>
-    @if (publicData()) {
-      @if (!publicData()?.length && !disabled()) {
-        <div class="lab900-table__empty">
-          @if (emptyTableTemplate()) {
-            <ng-container *ngTemplateOutlet="emptyTableTemplate()" />
-          } @else {
-            <h3>{{ 'GENERAL.NO_RESULTS.TITLE' | translate }}</h3>
-            <p>{{ 'GENERAL.NO_RESULTS.DESC' | translate }}</p>
-          }
-        </div>
-      } @else if (disabled()) {
-        <div>
-          @if (disabledTableTemplate()) {
-            <ng-container *ngTemplateOutlet="disabledTableTemplate()" />
-          } @else {
-            <h3>{{ 'GENERAL.DISABLED.TITLE' | translate }}</h3>
-            <p>{{ 'GENERAL.DISABLED.DESC' | translate }}</p>
-          }
-        </div>
+
+    <div style="position: relative">
+      @if (loading()) {
+        <mat-progress-bar mode="indeterminate" style="position: absolute; top: 0; left: 0; right: 0; z-index: 1" />
       }
-    }
+      <div class="lab900-table-wrapper" [class.sticky-header]="stickyHeader()">
+        <table
+          mat-table
+          cdkDropList
+          [cdkDropListDisabled]="!draggableRows()"
+          class="mat-elevation-z0"
+          [multiTemplateDataRows]="true"
+          [trackBy]="trackByTableFn()"
+          [dataSource]="publicData()"
+          (cdkDropListDropped)="tableRowOrderChange.emit($event)"
+          [class.has-back-actions]="tableActionsBack()?.length"
+          [class.has-front-actions]="tableActionsFront()?.length">
+          @if (selectableRows()?.enabled) {
+            <lab900-table-cell-select
+              [showFooter]="showCellFooters()"
+              [options]="selectableRows()"
+              [selection]="selection()"
+              (selectAll)="handleSelectAll($event)"
+              (selectRow)="handleSelectRow($event)" />
+          }
+          @for (column of visibleColumns(); track column.key) {
+            <lab900-table-cell
+              [cell]="column"
+              [disableSort]="disableSort()"
+              [maxColumnWidthFromTable]="maxColumnWidth()"
+              (headerClick)="handleHeaderClick($event)"
+              [data]="publicData()"
+              [showFooterCell]="showCellFooters()"
+              (valueChanged)="cellValueChanged.emit($event)" />
+          }
+          <ng-container matColumnDef="actions-front">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let element; let index = index" (click)="$event.stopPropagation()">
+              @if (tableActionsFront()?.length) {
+                <div class="table-row-actions-front">
+                  @for (action of tableActionsFront(); track action.label) {
+                    <lab900-action-button
+                      [data]="element"
+                      [action]="action"
+                      cdkDragHandle
+                      [cdkDragHandleDisabled]="!action?.draggable" />
+                  }
+                </div>
+              }
+            </td>
+            @if (showCellFooters()) {
+              <td mat-footer-cell *matFooterCellDef></td>
+            }
+          </ng-container>
+          <ng-container matColumnDef="actions-back" stickyEnd>
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let element; let index = index" (click)="$event.stopPropagation()">
+              @if (tableActionsBack()?.length) {
+                <div class="table-row-actions-back">
+                  @for (action of tableActionsBack(); track action.label) {
+                    <lab900-action-button
+                      [data]="element"
+                      [action]="action"
+                      cdkDragHandle
+                      [cdkDragHandleDisabled]="!action?.draggable" />
+                  }
+                </div>
+              }
+            </td>
+            @if (showCellFooters()) {
+              <td mat-footer-cell *matFooterCellDef></td>
+            }
+          </ng-container>
+          @if (displayedColumns()) {
+            <!-- header row -->
+            <tr mat-header-row *matHeaderRowDef="displayedColumns(); sticky: stickyHeader"></tr>
+            <!-- content rows -->
+            <tr
+              mat-row
+              *matRowDef="let row; columns: displayedColumns(); let i = dataIndex"
+              [ngClass]="getRowClasses(row, i)"
+              [class.lab900-row-selected]="isRowSelected(row)"
+              [style.background-color]="getRowColor(row)"
+              (click)="handleRowClick($event, row, i)"
+              cdkDrag
+              [cdkDragDisabled]="!draggableRows()"></tr>
+            @if (showCellFooters()) {
+              <div>
+                <!-- pre footer row -->
+                @if (preFooterTitle(); as preFooterTitle) {
+                  <ng-container matColumnDef="preFooterTitle">
+                    <td
+                      mat-footer-cell
+                      *matFooterCellDef
+                      [attr.colspan]="visibleColumns().length + 1"
+                      class="lab900-table__pre-footer-title-cell">
+                      {{ preFooterTitle | translate }}
+                    </td>
+                  </ng-container>
+                  <tr
+                    [hidden]="!publicData()?.length"
+                    mat-footer-row
+                    *matFooterRowDef="['preFooterTitle']"
+                    class="lab900-table__pre-footer-title-row"></tr>
+                }
+                <!-- footer row -->
+                <tr [hidden]="!publicData()?.length" mat-footer-row *matFooterRowDef="displayedColumns()"></tr>
+              </div>
+            }
+            <!-- drag placeholder -->
+            @if (draggableRows()) {
+              <div *cdkDragPlaceholder></div>
+            }
+          }
+        </table>
+      </div>
+      @if (publicData()) {
+        @if (!publicData()?.length && !disabled()) {
+          <div class="lab900-table__empty">
+            @if (emptyTableTemplate()) {
+              <ng-container *ngTemplateOutlet="emptyTableTemplate()" />
+            } @else {
+              <h3>{{ 'GENERAL.NO_RESULTS.TITLE' | translate }}</h3>
+              <p>{{ 'GENERAL.NO_RESULTS.DESC' | translate }}</p>
+            }
+          </div>
+        } @else if (disabled()) {
+          <div>
+            @if (disabledTableTemplate()) {
+              <ng-container *ngTemplateOutlet="disabledTableTemplate()" />
+            } @else {
+              <h3>{{ 'GENERAL.DISABLED.TITLE' | translate }}</h3>
+              <p>{{ 'GENERAL.DISABLED.DESC' | translate }}</p>
+            }
+          </div>
+        }
+      }
+    </div>
   </div>
 }

--- a/lib/src/lib/table/components/table/table.component.scss
+++ b/lib/src/lib/table/components/table/table.component.scss
@@ -11,6 +11,10 @@
     }
   }
 
+  .lab900-deferred-cell-placeholder {
+    height: 52px;
+  }
+
   &.fixed-widths {
     .mat-mdc-table {
       table-layout: fixed;
@@ -22,20 +26,14 @@
           }
         }
       }
-
-      &.has-back-actions {
-        tr.mat-mdc-row {
-          > :nth-last-child(2) {
-            // width: 100%;
-          }
-        }
-      }
     }
   }
 
   .lab900-table-wrapper {
     overflow: auto;
+    position: relative;
     width: 100%;
+    z-index: 0;
   }
 
   th.mat-mdc-header-cell,

--- a/lib/src/lib/table/directives/table-cell-events.directive.ts
+++ b/lib/src/lib/table/directives/table-cell-events.directive.ts
@@ -6,7 +6,7 @@ import { fromEvent } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Directive({
-  selector: 'td[lab900TableCellEvents]',
+  selector: '[lab900TableCellEvents]',
   standalone: true,
 })
 export class TableCellEventsDirective<T = any> implements AfterViewInit {

--- a/lib/src/lib/table/directives/table-cell-events.directive.ts
+++ b/lib/src/lib/table/directives/table-cell-events.directive.ts
@@ -12,7 +12,8 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 export class TableCellEventsDirective<T = any> implements AfterViewInit {
   private readonly matTable = inject(MatTable);
   private readonly tableService = inject(Lab900TableService);
-  private readonly elm: ElementRef<HTMLTableCellElement> = inject(ElementRef);
+  private readonly innerElm: ElementRef<HTMLElement> = inject(ElementRef);
+  private cellElement!: HTMLTableCellElement;
   private readonly ngZone = inject(NgZone);
   protected readonly destroyRef = inject(DestroyRef);
 
@@ -37,11 +38,16 @@ export class TableCellEventsDirective<T = any> implements AfterViewInit {
     if (!this.matTable || !this.matTable.dataSource) {
       throw new Error('MatTable [dataSource] is required');
     }
+    this.cellElement = this.innerElm.nativeElement.parentElement as HTMLTableCellElement;
+
+    if (!this.cellElement || this.cellElement.tagName !== 'TD') {
+      throw new Error('No parent td element found for TableCellEventsDirective');
+    }
 
     this.siblingCells = this.getAllSiblingCells();
-    this.cellIdx = this.siblingCells.indexOf(this.elm.nativeElement);
+    this.cellIdx = this.siblingCells.indexOf(this.cellElement);
     this.siblingRows = this.getAllSiblingRows();
-    this.rowIdx = this.siblingRows.indexOf(this.elm.nativeElement.parentElement as HTMLTableRowElement);
+    this.rowIdx = this.siblingRows.indexOf(this.cellElement.parentElement as HTMLTableRowElement);
 
     /**
      * Listen to keydown, focus and click events on the cell
@@ -49,19 +55,19 @@ export class TableCellEventsDirective<T = any> implements AfterViewInit {
      * Wrap the event handlers in `ngZone.run` to trigger change detection
      */
     this.ngZone.runOutsideAngular(() => {
-      fromEvent(this.elm.nativeElement, 'keydown')
+      fromEvent(this.cellElement, 'keydown')
         .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(event => {
           this.onKeydown(event as KeyboardEvent);
         });
 
-      fromEvent(this.elm.nativeElement, 'focus')
+      fromEvent(this.cellElement, 'focus')
         .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(() => {
           this.onFocus();
         });
 
-      fromEvent(this.elm.nativeElement, 'click')
+      fromEvent(this.cellElement, 'click')
         .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(event => {
           this.onClick(event as MouseEvent);
@@ -157,13 +163,13 @@ export class TableCellEventsDirective<T = any> implements AfterViewInit {
   }
 
   private getAllSiblingCells(): HTMLTableCellElement[] {
-    const elm: HTMLTableCellElement = this.elm.nativeElement;
+    const elm: HTMLTableCellElement = this.cellElement;
     const cells = elm.parentElement?.children;
     return cells ? ([...Array.from(cells)] as HTMLTableCellElement[]) : [];
   }
 
   private getAllSiblingRows(): HTMLTableRowElement[] {
-    const elm: HTMLTableCellElement = this.elm.nativeElement;
+    const elm: HTMLTableCellElement = this.cellElement;
     const rows = elm.parentElement?.parentElement?.children;
     return rows ? ([...Array.from(rows)] as HTMLTableRowElement[]) : [];
   }

--- a/src/app/modules/showcase-ui/examples/table-example/table-example.component.ts
+++ b/src/app/modules/showcase-ui/examples/table-example/table-example.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, signal, TrackByFunction } from '@angular/core';
+import { Component, signal, TrackByFunction } from '@angular/core';
 import {
   ActionButton,
   CellInputEditorComponent,
@@ -2848,7 +2848,7 @@ const mockData = [
   </lab900-table>`,
   styleUrls: ['table-example.component.scss'],
 })
-export class TableExampleComponent implements AfterViewInit {
+export class TableExampleComponent {
   public sort: Lab900Sort[] = [{ id: 'id', direction: 'asc' }];
 
   public tableHeaderActions: ActionButton[] = [
@@ -3033,12 +3033,5 @@ export class TableExampleComponent implements AfterViewInit {
 
   public onRowClick(row: any): void {
     console.log('Row clicked', row);
-  }
-
-  public ngAfterViewInit(): void {
-    setTimeout(() => {
-      this.tableCells.set([...this.tableCells()]);
-      this.mockData.set([]);
-    }, 1000);
   }
 }


### PR DESCRIPTION
While investigating performance problems for the STIP Product overview, I noticed that the table took 5-7 seconds after the data request finished. Since this is a huge data set the problem was likely in our library. 

Improvements:
- deferred table cells -> This means only the cells in view will be rendered directly. This had a huge impact on the load time.
- made the loader position absolute so that the loading state doesn't cause a layout shift in the entire table

Before deferred:

![Scherm­afbeelding 2024-10-14 om 15 02 01](https://github.com/user-attachments/assets/09dfa114-9062-4266-99e6-a37910414f39)

After deferred:

![Scherm­afbeelding 2024-10-14 om 15 00 57](https://github.com/user-attachments/assets/4c58d237-6d21-43d5-b274-04c45521368d)

