### PR TITLE
feat: add tooltips to action menu items (sub-actions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 18.1.5
+- add tooltips to action menu items (sub-actions)
 
 ## 18.1.4
 - adjusting id's to buttons for testing purposes

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/ui",
-  "version": "18.1.4",
+  "version": "18.1.5",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {

--- a/lib/src/lib/button/components/action-button-menu/lab900-action-button-menu.component.html
+++ b/lib/src/lib/button/components/action-button-menu/lab900-action-button-menu.component.html
@@ -5,6 +5,8 @@
         mat-menu-item
         (throttledClick)="doAction($event, action)"
         [disabled]="getDisabled(action) | async"
+        [matTooltip]="action?.tooltip?.value | translate"
+        [matTooltipPosition]="action?.tooltip?.position ?? 'left'"
         lab900PreventDoubleClick>
         @if (action.prefixIcon) {
           <mat-icon>{{ getPrefixIcon(action) }}</mat-icon>
@@ -19,6 +21,8 @@
         mat-menu-item
         [matMenuTriggerFor]="innerMenu.actionMenu"
         [disabled]="getDisabled(action) | async"
+        [matTooltip]="action?.tooltip?.value | translate"
+        [matTooltipPosition]="action?.tooltip?.position ?? 'left'"
         lab900PreventDoubleClick>
         @if (action.prefixIcon) {
           <mat-icon>{{ getPrefixIcon(action) }}</mat-icon>

--- a/lib/src/lib/button/components/action-button-menu/lab900-action-button-menu.component.ts
+++ b/lib/src/lib/button/components/action-button-menu/lab900-action-button-menu.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, ViewChild } from '@angular/core';
+import { MatTooltip } from '@angular/material/tooltip';
 import { ActionButton } from '../../models/action-button.model';
 import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
 import { coerceObservable, readPropValue } from '../../../utils/utils';
@@ -13,7 +14,16 @@ import { map } from 'rxjs/operators';
   selector: 'lab900-action-button-menu',
   templateUrl: './lab900-action-button-menu.component.html',
   standalone: true,
-  imports: [MatMenu, MatIcon, MatMenuItem, MatMenuTrigger, AsyncPipe, TranslateModule, PreventDoubleClickDirective],
+  imports: [
+    MatMenu,
+    MatIcon,
+    MatMenuItem,
+    MatMenuTrigger,
+    AsyncPipe,
+    TranslateModule,
+    PreventDoubleClickDirective,
+    MatTooltip,
+  ],
 })
 export class Lab900ActionButtonMenuComponent {
   @ViewChild('actionMenu', { static: true })

--- a/src/app/modules/showcase-ui/examples/table-example/table-example.component.ts
+++ b/src/app/modules/showcase-ui/examples/table-example/table-example.component.ts
@@ -2874,6 +2874,9 @@ export class TableExampleComponent {
           label: 'Word',
           type: 'stroked',
           action: () => console.log('Word'),
+          tooltip: {
+            value: 'Exporteer naar een Word document',
+          },
         },
         {
           label: 'PDF',


### PR DESCRIPTION
- support for tooltips in subactions of an action menu
- model of ActionButton already supported the tooltip, was just not added in HTML of sub-actions
- updated version of lib + added tag to commit

![image](https://github.com/user-attachments/assets/d391aa52-7785-4db4-b39c-80ebfce2c72f)
