### PR TITLE
feat: make-subactions-reactive-to-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## 19.1.5
+## 19.2.0
+#### Breaking Changes
 - ActionButton's sub-actions now support reactive options.
 Meaning the number of sub-actions can change dynamically based on the row-data of a table. (e.g. every row having a 
-  different number of files to download)
+  different number of files to download). This can be breaking if you were dynamically adding sub-actions to the 
+  array after initialization.
 
 ## 19.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 19.1.4
+## 19.1.5
 - ActionButton's sub-actions now support reactive options.
 Meaning the number of sub-actions can change dynamically based on the row-data of a table. (e.g. every row having a 
   different number of files to download)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Meaning the number of sub-actions can change dynamically based on the row-data o
   different number of files to download). This can be breaking if you were dynamically adding sub-actions to the 
   array after initialization.
 
+## 19.1.5
+- this version is deprecated, and the version tag was removed, since it contains some breaking changes in comparison to 
+  19.1.4
+
 ## 19.1.0
 
 ### Action Menu/Button/Toggle Improvements

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/ui",
-  "version": "19.1.4",
+  "version": "19.1.5",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/ui",
-  "version": "19.1.5",
+  "version": "19.2.0",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
version bump because the last one was not updated on main branch