### PR TITLE
Feat/show hidden and active columns header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 19.2.1
+### Show header filter fixes
+- Fixed an issue where the header filter would not show up when `visibleCells` and `hiddenCells` contains items and add new param `showHeaderFilter` to explicitly show/hide the header filter.
+
 ## 19.2.0
 #### Breaking Changes
 - ActionButton's sub-actions now support reactive options.

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/ui",
-  "version": "19.2.0",
+  "version": "19.2.1",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {

--- a/lib/src/lib/table/components/table-filter-menu/table-filter-menu.component.html
+++ b/lib/src/lib/table/components/table-filter-menu/table-filter-menu.component.html
@@ -17,7 +17,7 @@
       } @else {
         <!-- ACTIVE COLUMNS -->
         @if (visibleCells()) {
-          @if (visibleCells()?.length > 0) {
+          @if (showFilterHeader() && visibleCells()?.length > 0) {
             <div
               (click)="$event.stopPropagation(); $event.preventDefault()"
               class="lab900-table-filter-menu__option lab900-table-filter-menu__option--bold lab900-table-filter-menu__title">
@@ -55,7 +55,7 @@
         }
         <!-- INACTIVE COLUMNS -->
         @if (hiddenCells()) {
-          @if (hiddenCells()?.length > 0) {
+          @if (showFilterHeader() && hiddenCells()?.length > 0) {
             <div
               (click)="$event.stopPropagation(); $event.preventDefault()"
               class="lab900-table-filter-menu__option lab900-table-filter-menu__option--bold lab900-table-filter-menu__title lab900-table-filter-menu__title--middle">

--- a/lib/src/lib/table/components/table-filter-menu/table-filter-menu.component.html
+++ b/lib/src/lib/table/components/table-filter-menu/table-filter-menu.component.html
@@ -17,7 +17,7 @@
       } @else {
         <!-- ACTIVE COLUMNS -->
         @if (visibleCells()) {
-          @if (visibleCells?.length > 0) {
+          @if (visibleCells()?.length > 0) {
             <div
               (click)="$event.stopPropagation(); $event.preventDefault()"
               class="lab900-table-filter-menu__option lab900-table-filter-menu__option--bold lab900-table-filter-menu__title">
@@ -55,7 +55,7 @@
         }
         <!-- INACTIVE COLUMNS -->
         @if (hiddenCells()) {
-          @if (hiddenCells?.length > 0) {
+          @if (hiddenCells()?.length > 0) {
             <div
               (click)="$event.stopPropagation(); $event.preventDefault()"
               class="lab900-table-filter-menu__option lab900-table-filter-menu__option--bold lab900-table-filter-menu__title lab900-table-filter-menu__title--middle">

--- a/lib/src/lib/table/components/table-filter-menu/table-filter-menu.component.ts
+++ b/lib/src/lib/table/components/table-filter-menu/table-filter-menu.component.ts
@@ -51,6 +51,7 @@ export class Lab900TableFilterMenuComponent {
   protected readonly hiddenCells = computed(() => this.filterableTableCells().filter((cell: TableCell) => !!cell.hide));
 
   public filterIcon = input<string>('filter_alt');
+  public showFilterHeader = input<boolean>(false);
   public toggleAndMoveColumns = input<boolean>(false);
 
   public readonly filterChanged = output<TableCell[]>();

--- a/lib/src/lib/table/components/table-filter-menu/table-filter-menu.component.ts
+++ b/lib/src/lib/table/components/table-filter-menu/table-filter-menu.component.ts
@@ -51,7 +51,7 @@ export class Lab900TableFilterMenuComponent {
   protected readonly hiddenCells = computed(() => this.filterableTableCells().filter((cell: TableCell) => !!cell.hide));
 
   public filterIcon = input<string>('filter_alt');
-  public showFilterHeader = input<boolean>(false);
+  public showFilterHeader = input<boolean>(true);
   public toggleAndMoveColumns = input<boolean>(false);
 
   public readonly filterChanged = output<TableCell[]>();

--- a/lib/src/lib/table/components/table-header/lab900-table-header.component.html
+++ b/lib/src/lib/table/components/table-header/lab900-table-header.component.html
@@ -14,6 +14,7 @@
       <lab900-table-filter-menu
         (filterChanged)="tableCellsFiltered.emit($event)"
         [filterIcon]="filterIcon()"
+        [showFilterHeader]="showFilterHeader()"
         [toggleAndMoveColumns]="toggleAndMoveColumns()" />
     }
   </div>

--- a/lib/src/lib/table/components/table-header/lab900-table-header.component.ts
+++ b/lib/src/lib/table/components/table-header/lab900-table-header.component.ts
@@ -25,7 +25,7 @@ export class Lab900TableHeaderComponent {
   public readonly tableHeaderContent = input<TemplateRef<any> | undefined>(undefined);
   public readonly tableHeaderActions = input<ActionButton[]>([]);
   public readonly filterIcon = input<string>('filter_alt');
-  public readonly showFilterHeader = input<boolean>(false);
+  public readonly showFilterHeader = input<boolean>(true);
   public readonly toggleAndMoveColumns = input<boolean>(false);
   public readonly toggleColumns = input<boolean>(true);
 

--- a/lib/src/lib/table/components/table-header/lab900-table-header.component.ts
+++ b/lib/src/lib/table/components/table-header/lab900-table-header.component.ts
@@ -25,6 +25,7 @@ export class Lab900TableHeaderComponent {
   public readonly tableHeaderContent = input<TemplateRef<any> | undefined>(undefined);
   public readonly tableHeaderActions = input<ActionButton[]>([]);
   public readonly filterIcon = input<string>('filter_alt');
+  public readonly showFilterHeader = input<boolean>(false);
   public readonly toggleAndMoveColumns = input<boolean>(false);
   public readonly toggleColumns = input<boolean>(true);
 

--- a/lib/src/lib/table/components/table/table.component.html
+++ b/lib/src/lib/table/components/table/table.component.html
@@ -5,6 +5,7 @@
       [toggleColumns]="toggleColumns()"
       [toggleAndMoveColumns]="toggleAndMoveColumns()"
       [filterIcon]="filterIcon()"
+      [showFilterHeader]="showFilterHeader()"
       [tableHeaderContent]="tableHeaderContent()"
       (tableCellsFiltered)="onTableCellsFiltered($event)" />
     @if (tableTopContent(); as tableTopContent) {

--- a/lib/src/lib/table/components/table/table.component.ts
+++ b/lib/src/lib/table/components/table/table.component.ts
@@ -192,6 +192,7 @@ export class Lab900TableComponent<T extends object = object, TabId = string> {
    */
   public readonly toggleAndMoveColumns = input<boolean>(false);
   public readonly filterIcon = input<string>('filter_alt');
+  public readonly showFilterHeader = input<boolean>(false);
   public readonly neverHideTable = input<boolean>(false);
   public readonly disabled = model<boolean>(false);
 

--- a/lib/src/lib/table/components/table/table.component.ts
+++ b/lib/src/lib/table/components/table/table.component.ts
@@ -192,7 +192,7 @@ export class Lab900TableComponent<T extends object = object, TabId = string> {
    */
   public readonly toggleAndMoveColumns = input<boolean>(false);
   public readonly filterIcon = input<string>('filter_alt');
-  public readonly showFilterHeader = input<boolean>(false);
+  public readonly showFilterHeader = input<boolean>(true);
   public readonly neverHideTable = input<boolean>(false);
   public readonly disabled = model<boolean>(false);
 


### PR DESCRIPTION
There was an issue that the header of the filter `Active columns` and `Hidden columns` were not shown up.
I added as well a param to let the user decides whatever they want to see it or not.