### PR TITLE
fix: header filter menu only toggle columns

### DIFF
--- a/lib/src/lib/table/components/table-filter-menu/table-filter-menu.component.html
+++ b/lib/src/lib/table/components/table-filter-menu/table-filter-menu.component.html
@@ -4,26 +4,32 @@
       <mat-icon>{{ filterIcon() }}</mat-icon>
     </button>
     <mat-menu #filterMenu class="lab900-table-filter-menu__mat-menu">
-      @if (!toggleAndMoveColumns()) {
-        @for (cell of filterableTableCells(); track cell.key) {
-          <div class="lab900-table-filter-menu__option">
-            <div class="lab900-table-filter-menu__option--padding">
-              <mat-checkbox (click)="handleCheckboxClick($event, cell)" [checked]="!cell.hide" color="primary">
-                {{ getCellLabel(cell) | translate }}
-              </mat-checkbox>
-            </div>
+      <!-- ACTIVE COLUMNS -->
+      @if (visibleCells()) {
+        @if (showFilterHeader() && visibleCells()?.length > 0) {
+          <div
+            (click)="$event.stopPropagation(); $event.preventDefault()"
+            class="lab900-table-filter-menu__option lab900-table-filter-menu__option--bold lab900-table-filter-menu__title">
+            {{ 'ui.table.active_columns' | translate }}
           </div>
         }
-      } @else {
-        <!-- ACTIVE COLUMNS -->
-        @if (visibleCells()) {
-          @if (showFilterHeader() && visibleCells()?.length > 0) {
-            <div
-              (click)="$event.stopPropagation(); $event.preventDefault()"
-              class="lab900-table-filter-menu__option lab900-table-filter-menu__option--bold lab900-table-filter-menu__title">
-              {{ 'ui.table.active_columns' | translate }}
-            </div>
-          }
+        @if (!toggleAndMoveColumns()) {
+          <div class="lab900-table-filter-menu__items-container">
+            @for (cell of visibleCells(); track cell.key) {
+              <div (click)="handleCheckboxClick($event, cell)" class="lab900-table-filter-menu__option">
+                <div class="lab900-table-filter-menu__option--padding">
+                  <mat-checkbox
+                    [checked]="!cell.hide"
+                    [labelPosition]="'before'"
+                    class="lab900-table-filter-menu__checkbox"
+                    color="primary">
+                    {{ getCellLabel(cell) | translate }}
+                  </mat-checkbox>
+                </div>
+              </div>
+            }
+          </div>
+        } @else {
           <div cdkScrollable class="lab900-table-filter-menu__items-container">
             <div (cdkDropListDropped)="drop($event)" [cdkDropListData]="visibleCells()" cdkDropList>
               @for (cell of visibleCells(); track cell.key) {
@@ -53,31 +59,31 @@
             </div>
           </div>
         }
-        <!-- INACTIVE COLUMNS -->
-        @if (hiddenCells()) {
-          @if (showFilterHeader() && hiddenCells()?.length > 0) {
-            <div
-              (click)="$event.stopPropagation(); $event.preventDefault()"
-              class="lab900-table-filter-menu__option lab900-table-filter-menu__option--bold lab900-table-filter-menu__title lab900-table-filter-menu__title--middle">
-              {{ 'ui.table.inactive_columns' | translate }}
-            </div>
-          }
-          <div class="lab900-table-filter-menu__items-container">
-            @for (cell of hiddenCells(); track cell.key) {
-              <div (click)="handleCheckboxClick($event, cell)" class="lab900-table-filter-menu__option">
-                <div class="lab900-table-filter-menu__option--padding">
-                  <mat-checkbox
-                    [checked]="!cell.hide"
-                    [labelPosition]="'before'"
-                    class="lab900-table-filter-menu__checkbox"
-                    color="primary">
-                    {{ getCellLabel(cell) | translate }}
-                  </mat-checkbox>
-                </div>
-              </div>
-            }
+      }
+      <!-- INACTIVE COLUMNS -->
+      @if (hiddenCells()) {
+        @if (showFilterHeader() && hiddenCells()?.length > 0) {
+          <div
+            (click)="$event.stopPropagation(); $event.preventDefault()"
+            class="lab900-table-filter-menu__option lab900-table-filter-menu__option--bold lab900-table-filter-menu__title lab900-table-filter-menu__title--middle">
+            {{ 'ui.table.inactive_columns' | translate }}
           </div>
         }
+        <div class="lab900-table-filter-menu__items-container">
+          @for (cell of hiddenCells(); track cell.key) {
+            <div (click)="handleCheckboxClick($event, cell)" class="lab900-table-filter-menu__option">
+              <div class="lab900-table-filter-menu__option--padding">
+                <mat-checkbox
+                  [checked]="!cell.hide"
+                  [labelPosition]="'before'"
+                  class="lab900-table-filter-menu__checkbox"
+                  color="primary">
+                  {{ getCellLabel(cell) | translate }}
+                </mat-checkbox>
+              </div>
+            </div>
+          }
+        </div>
       }
     </mat-menu>
   </div>


### PR DESCRIPTION
When the `toggleColumns` is set on true:
<img width="1255" height="853" alt="image" src="https://github.com/user-attachments/assets/40d3c86e-d64e-482f-9271-1a97fba7f75a" />
With hidden cells
<img width="1227" height="907" alt="image" src="https://github.com/user-attachments/assets/a2027f66-3ea8-445e-92b8-b8bf4cf510b0" />


Before it reacts like this:
All cells are visibles:
<img width="1271" height="898" alt="image" src="https://github.com/user-attachments/assets/c5e3d101-dbac-452f-ac43-94daf4b9aedc" />

Some cells are hidden: (Status and nominated quantity are hidden in the table which is ok but not properly shown in the filter header)
<img width="1257" height="831" alt="image" src="https://github.com/user-attachments/assets/f2158a02-22fc-43ab-93a5-40f38c86b55f" />

