### PR TITLE
fix/19.2.7 table-single-sort-can-disable-sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 19.2.7
-- Fix: table with input "multiSort=false" will now be able to toggle between 'asc', 'desc', and 'no sorting', instead of just asc and desc.
+- Fix: table with input "multiSort=false" will now be able to toggle between 'asc', 'desc', and 'no sorting', instead of just 'asc' and 'desc'.
 
 ## 19.2.6
 - Feat: add support dynamic tooltip on action button

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 19.2.7
+- Fix: table with input "multiSort=false" will now be able to toggle between 'asc', 'desc', and 'no sorting', instead of just asc and desc.
+
 ## 19.2.6
 - Feat: add support dynamic tooltip on action button
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/ui",
-  "version": "19.2.6",
+  "version": "19.2.7",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {

--- a/lib/src/lib/table/services/table.service.ts
+++ b/lib/src/lib/table/services/table.service.ts
@@ -43,31 +43,32 @@ export class Lab900TableService<T extends object = object, TabId = string> {
     callback?: (sort: Lab900Sort[] | undefined) => void
   ): void {
     const sortKey = column.sortKey ?? column.key;
-    this.sort.update((sort = []) => {
-      if (multiSort) {
-        const currentIndex = sort.findIndex(s => s.id === sortKey);
-        if (currentIndex >= 0) {
-          const { direction } = sort[currentIndex];
-          if (direction === 'desc') {
-            sort.splice(currentIndex, 1);
-          } else {
-            sort[currentIndex] = { ...sort[currentIndex], direction: 'desc' };
-          }
-        } else {
-          sort.push({ id: sortKey, direction: 'asc' });
-        }
-        return [...sort];
-      } else {
-        const inCurrent = sort.find(s => s.id === sortKey);
-        return [
-          {
-            id: sortKey,
-            direction: inCurrent?.direction === 'asc' ? 'desc' : 'asc',
-          },
-        ];
-      }
-    });
+    this.sort.update((currentSort = []) =>
+      multiSort ? this.toggleMultiSort(currentSort, sortKey) : this.toggleSingleSort(currentSort, sortKey)
+    );
     callback?.(this.sort());
+  }
+
+  private toggleMultiSort(sort: Lab900Sort[], sortKey: string): Lab900Sort[] {
+    const currentIndex = sort.findIndex(s => s.id === sortKey);
+    if (currentIndex < 0) {
+      return [...sort, { id: sortKey, direction: 'asc' }];
+    }
+    if (sort[currentIndex].direction === 'desc') {
+      return sort.filter((_, i) => i !== currentIndex);
+    }
+    return sort.map((s, i) => (i === currentIndex ? { ...s, direction: 'desc' as const } : s));
+  }
+
+  private toggleSingleSort(sort: Lab900Sort[], sortKey: string): Lab900Sort[] {
+    const current = sort.find(s => s.id === sortKey);
+    if (!current) {
+      return [{ id: sortKey, direction: 'asc' }];
+    }
+    if (current.direction === 'asc') {
+      return [{ id: sortKey, direction: 'desc' }];
+    }
+    return [];
   }
 
   public startInlineEditing(cellKey: string): void {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-library-ui",
-  "version": "19.2.6",
+  "version": "19.2.7",
   "repository": "https://github.com/lab900/angular-library-ui",
   "homepage": "https://github.com/lab900/angular-library-ui",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",


### PR DESCRIPTION
- table with input "multiSort=false" will now be able to toggle between 'asc', 'desc', and 'no sorting', instead of just 'asc' and 'desc'.
